### PR TITLE
Add commenting only on change to successful deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,9 +157,13 @@ pipeline {
         }
       }
       post {
-        success {
-          echo "Successfully deployed to https://${HOST_ROUTE}"
-          notifyStageStatus('Deploy', 'SUCCESS')
+        changed {
+          script {
+            if(currentBuild.currentResult.equalsIgnoreCase('SUCCESS')) {
+              echo "Successfully deployed to https://${HOST_ROUTE}"
+              notifyStageStatus('Deploy', 'SUCCESS')
+            }
+          }
         }
         unsuccessful {
           echo 'Deploy failed'
@@ -184,4 +188,9 @@ def notifyStageStatus(String name, String status) {
     '',
     "Stage: ${name}"
   )
+}
+
+// Creates a comment and pass to Jenkins-GitHub library
+def commentOnPR(String comment) {
+  GitHubHelper.commentOnPullRequest(this, comment)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,13 +157,9 @@ pipeline {
         }
       }
       post {
-        changed {
-          script {
-            if(currentBuild.currentResult.equalsIgnoreCase('SUCCESS')) {
-              echo "Successfully deployed to https://${HOST_ROUTE}"
-              notifyStageStatus('Deploy', 'SUCCESS')
-            }
-          }
+        success {
+          echo "Successfully deployed to https://${HOST_ROUTE}"
+          notifyStageStatus('Deploy', 'SUCCESS')
         }
         unsuccessful {
           echo 'Deploy failed'

--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -157,9 +157,14 @@ pipeline {
         }
       }
       post {
-        success {
-          echo "Successfully deployed to https://${HOST_ROUTE}"
-          notifyStageStatus('Deploy', 'SUCCESS')
+        changed {
+          script {
+            if(currentBuild.currentResult.equalsIgnoreCase('SUCCESS')) {
+              echo "Successfully deployed to https://${HOST_ROUTE}"
+              commentOnPR("Deployed to https://${HOST_ROUTE}")
+              notifyStageStatus('Deploy', 'SUCCESS')
+            }
+          }
         }
         unsuccessful {
           echo 'Deploy failed'
@@ -184,4 +189,9 @@ def notifyStageStatus(String name, String status) {
     '',
     "Stage: ${name}"
   )
+}
+
+// Creates a comment and pass to Jenkins-GitHub library
+def commentOnPR(String comment) {
+  GitHubHelper.commentOnPullRequest(this, comment)
 }

--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -157,18 +157,24 @@ pipeline {
         }
       }
       post {
-        changed {
-          script {
-            if(currentBuild.currentResult.equalsIgnoreCase('SUCCESS')) {
-              echo "Successfully deployed to https://${HOST_ROUTE}"
-              commentOnPR("Deployed to https://${HOST_ROUTE}")
-              notifyStageStatus('Deploy', 'SUCCESS')
-            }
-          }
+        success {
+          echo "Successfully deployed to https://${HOST_ROUTE}"
+          notifyStageStatus('Deploy', 'SUCCESS')
         }
         unsuccessful {
           echo 'Deploy failed'
           notifyStageStatus('Deploy', 'FAILURE')
+        }
+      }
+    }
+  }
+  post {
+    changed {
+      script {
+        // Comment on Pull Request if build changes to successful
+        if(currentBuild.currentResult.equalsIgnoreCase('SUCCESS')) {
+          echo "Posting comment 'Deployed to https://${HOST_ROUTE}' to Pull Request..."
+          commentOnPR("Deployed to https://${HOST_ROUTE}")
         }
       }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR makes the pipeline emit a comment when there is a successful deployment. It should emit a URL for the associated deployment.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
