### PR TITLE
Change pipeline bc cleanup behavior on debug

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,18 +117,18 @@ pipeline {
               openshift.withProject(TOOLS_PROJECT) {
                 if(DEBUG_OUTPUT) {
                   echo "DEBUG - Using project: ${openshift.project()}"
-                }
+                } else {
+                  def bcFrontend = openshift.selector('bc', "${REPO_NAME}-frontend-${JOB_NAME}")
+                  def bcFrontendStatic = openshift.selector('bc', "${REPO_NAME}-frontend-static-${JOB_NAME}")
 
-                def bcFrontend = openshift.selector('bc', "${REPO_NAME}-frontend-${JOB_NAME}")
-                def bcFrontendStatic = openshift.selector('bc', "${REPO_NAME}-frontend-static-${JOB_NAME}")
-
-                if(bcFrontend.exists()) {
-                  echo "Removing BuildConfig ${REPO_NAME}-frontend-${JOB_NAME}..."
-                  bcFrontend.delete()
-                }
-                if(bcFrontendStatic.exists()) {
-                  echo "Removing BuildConfig ${REPO_NAME}-frontend-static-${JOB_NAME}..."
-                  bcFrontendStatic.delete()
+                  if(bcFrontend.exists()) {
+                    echo "Removing BuildConfig ${REPO_NAME}-frontend-${JOB_NAME}..."
+                    bcFrontend.delete()
+                  }
+                  if(bcFrontendStatic.exists()) {
+                    echo "Removing BuildConfig ${REPO_NAME}-frontend-static-${JOB_NAME}..."
+                    bcFrontendStatic.delete()
+                  }
                 }
               }
             }

--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -117,18 +117,18 @@ pipeline {
               openshift.withProject(TOOLS_PROJECT) {
                 if(DEBUG_OUTPUT) {
                   echo "DEBUG - Using project: ${openshift.project()}"
-                }
+                } else {
+                  def bcFrontend = openshift.selector('bc', "${REPO_NAME}-frontend-${JOB_NAME}")
+                  def bcFrontendStatic = openshift.selector('bc', "${REPO_NAME}-frontend-static-${JOB_NAME}")
 
-                def bcFrontend = openshift.selector('bc', "${REPO_NAME}-frontend-${JOB_NAME}")
-                def bcFrontendStatic = openshift.selector('bc', "${REPO_NAME}-frontend-static-${JOB_NAME}")
-
-                if(bcFrontend.exists()) {
-                  echo "Removing BuildConfig ${REPO_NAME}-frontend-${JOB_NAME}..."
-                  bcFrontend.delete()
-                }
-                if(bcFrontendStatic.exists()) {
-                  echo "Removing BuildConfig ${REPO_NAME}-frontend-static-${JOB_NAME}..."
-                  bcFrontendStatic.delete()
+                  if(bcFrontend.exists()) {
+                    echo "Removing BuildConfig ${REPO_NAME}-frontend-${JOB_NAME}..."
+                    bcFrontend.delete()
+                  }
+                  if(bcFrontendStatic.exists()) {
+                    echo "Removing BuildConfig ${REPO_NAME}-frontend-static-${JOB_NAME}..."
+                    bcFrontendStatic.delete()
+                  }
                 }
               }
             }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR changes the behavior of the cleanup step for the build configs so that they are not removed should debug output mode be set to true.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
