### PR TITLE
Ensure Patroni is up first before frontend and backend may proceed

### DIFF
--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -351,11 +351,21 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
         openshift.create(dcPatroniSecretTemplate)
       }
 
-      echo "Tagging Image ${REPO_NAME}-backend:${JOB_NAME}..."
-      openshift.tag("${TOOLS_PROJECT}/${REPO_NAME}-backend:${JOB_NAME}", "${REPO_NAME}-backend:${JOB_NAME}")
+      createDeploymentStatus(projectEnv, 'PENDING', hostRouteEnv)
 
-      echo "Tagging Image ${REPO_NAME}-frontend-static:${JOB_NAME} Deployment..."
-      openshift.tag("${TOOLS_PROJECT}/${REPO_NAME}-frontend-static:${JOB_NAME}", "${REPO_NAME}-frontend-static:${JOB_NAME}")
+      // Apply Patroni Database
+      timeout(10) {
+        echo "Processing Patroni StatefulSet.."
+        def dcPatroniTemplate = openshift.process('-f',
+          'openshift/patroni-ephemeral.dc.yaml',
+          "APP_NAME=${APP_NAME}",
+          "INSTANCE=${JOB_NAME}"
+        )
+
+        echo "Applying Patroni StatefulSet..."
+        def dcPatroni = openshift.apply(dcPatroniTemplate).narrow('statefulset')
+        dcPatroni.rollout().status('--watch=true')
+      }
 
       createDeploymentStatus(projectEnv, 'PENDING', hostRouteEnv)
 
@@ -364,6 +374,9 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
         parallel(
           Backend: {
             // Apply Backend Server
+            echo "Tagging Image ${REPO_NAME}-backend:${JOB_NAME}..."
+            openshift.tag("${TOOLS_PROJECT}/${REPO_NAME}-backend:${JOB_NAME}", "${REPO_NAME}-backend:${JOB_NAME}")
+
             echo "Processing DeploymentConfig ${REPO_NAME}-backend..."
             def dcBackendTemplate = openshift.process('-f',
               'openshift/backend.dc.yaml',
@@ -379,22 +392,11 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
             dcBackend.rollout().status('--watch=true')
           },
 
-          Database: {
-            // Apply Patroni Database
-            echo "Processing Patroni StatefulSet.."
-            def dcPatroniTemplate = openshift.process('-f',
-              'openshift/patroni-ephemeral.dc.yaml',
-              "APP_NAME=${APP_NAME}",
-              "INSTANCE=${JOB_NAME}"
-            )
-
-            echo "Applying Patroni StatefulSet..."
-            def dcPatroni = openshift.apply(dcPatroniTemplate).narrow('sts')
-            dcPatroni.rollout().status('--watch=true')
-          },
-
           Frontend: {
             // Apply Frontend Server
+            echo "Tagging Image ${REPO_NAME}-frontend-static:${JOB_NAME} Deployment..."
+            openshift.tag("${TOOLS_PROJECT}/${REPO_NAME}-frontend-static:${JOB_NAME}", "${REPO_NAME}-frontend-static:${JOB_NAME}")
+
             echo "Processing ${REPO_NAME}-frontend-static Deployment..."
             def dcFrontendStaticTemplate = openshift.process('-f',
               'openshift/frontend-static.dc.yaml',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This changes the pipeline so that it will explicitly wait for the Patroni StatefulSet to be up and running before proceeding further with backend/frontend deployment.
<!-- Why is this change required? What problem does it solve? -->
This is needed in order to ensure that the deployment doesn't fail due to the DB not being ready yet.
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->