### PR TITLE
New acronyms endpoint and db changes

### DIFF
--- a/backend/src/components/acronyms.js
+++ b/backend/src/components/acronyms.js
@@ -12,8 +12,9 @@ const acronyms = {
    */
   getAcronym: async (applicationAcronym) => {
     if (!applicationAcronym) {
-      log.error('getAcronym', 'No app acronym supplied to getAcronym');
-      throw new Error('No app acronym supplied to getAcronym');
+      const errMsg = 'No app acronym supplied to getAcronym';
+      log.error('getAcronym', errMsg);
+      throw new Error(errMsg);
     }
     try {
       const acronymDetails = await acronymService.find(applicationAcronym);

--- a/backend/src/components/acronyms.js
+++ b/backend/src/components/acronyms.js
@@ -1,0 +1,33 @@
+const log = require('npmlog');
+
+const {
+  acronymService
+} = require('../services');
+const utils = require('./utils');
+
+const acronyms = {
+  /**
+   * Fetch a specific acronym's application detail from GETOK database.
+   * @param {string} applicationAcronym - The app specifier.
+   */
+  getAcronym: async (applicationAcronym) => {
+    if (!applicationAcronym) {
+      log.error('getAcronym', 'No app acronym supplied to getAcronym');
+      throw new Error('No app acronym supplied to getAcronym');
+    }
+    try {
+      const acronymDetails = await acronymService.find(applicationAcronym);
+      log.verbose('getAcronym', utils.prettyStringify(acronymDetails));
+      if (acronymDetails) {
+        return acronymDetails;
+      } else {
+        return null;
+      }
+    } catch (error) {
+      log.error('getAcronym', error.message);
+      throw new Error(`An error occured fetching acronym details from GETOK database. ${error.message}`);
+    }
+  }
+};
+
+module.exports = acronyms;

--- a/backend/src/components/utils.js
+++ b/backend/src/components/utils.js
@@ -73,7 +73,6 @@ const utils = {
   // Returns only app acronym based roles
   filterAppAcronymRoles: roles => roles.filter(role => !role.match(/offline_access|uma_authorization|WEBADE_CFG_READ|WEBADE_CFG_READ_ALL/)),
 
-
   /**
   * From the big list of webade configs, return all APPLICATION preferences that match the search critera in the name that are not masked
   * @param {string} webadeConfigsList - The array of all the webade configs.
@@ -134,6 +133,44 @@ const utils = {
     } else {
       log.error('filterWebAdeDependencies', 'Error in supplied webade configuration list');
       throw new Error('Unable to fetch dependencies - Error in supplied webade configuration list');
+    }
+  },
+
+  /**
+  * Is this call allowed to be made for the acronym it's being made for?
+  * @param {string} token - The user's token from the request.
+  * @param {string} acronym - The app acronym.
+  * @returns {string} Error Message - Undefined if permitted, a string of the error message to return if not permitted.
+  */
+  checkAcronymPermission: (token, applicationAcronym) => {
+    // TODO: a lot of this role checking is duplicate, but as we will be moving acronym management to the DB soon all this will need to be refactored anyways
+
+    // Get Acronyms from user token
+    let acronyms = [];
+    const roles = token.realm_access.roles;
+    if (typeof roles === 'object' && roles instanceof Array) {
+      acronyms = utils.filterAppAcronymRoles(roles);
+    }
+
+    // Do they have access to the Acronym they are trying to POST
+    const appAcronym = applicationAcronym;
+    if (!acronyms.includes(applicationAcronym)) {
+      log.verbose(`User not authorized for acronym ${applicationAcronym}. Token: ${utils.prettyStringify(token)}`);
+      return `User lacks permission for '${appAcronym}' acronym`;
+    }
+  },
+
+  /**
+  * Is this call allowed to post the WebADE config details?
+  * @param {string} token - The user's token from the request.
+  * @param {string} configForm - The form posted to the post enpoint.
+  * @returns {string} Error Message - Undefined if permitted, a string of the error message to return if not permitted.
+  */
+  checkWebAdePostPermissions: (token, configForm) => {
+    // Do they have access to the Acronym they are trying to POST
+    const acronymAccessError = utils.checkAcronymPermission(token, configForm.applicationAcronym);
+    if (acronymAccessError) {
+      return acronymAccessError;
     }
   }
 };

--- a/backend/src/docs/v1.api-spec.yaml
+++ b/backend/src/docs/v1.api-spec.yaml
@@ -318,10 +318,10 @@ components:
         name:
           type: string
           example: Messaging Service Showcase
-        webadePermission:
+        permissionWebade:
           type: boolean
           example: true
-        webadeNrosDmsPermission:
+        permissionWebadeNrosDms:
           type: boolean
           example: false
     AppConfig:

--- a/backend/src/docs/v1.api-spec.yaml
+++ b/backend/src/docs/v1.api-spec.yaml
@@ -19,6 +19,38 @@ security:
   - bearerAuth: []
   - OpenID: []
 paths:
+  '/acronyms/{acronym}':
+    get:
+      summary: Returns the details that GETOK stores about an application acronym
+      operationId: getAcronym
+      tags:
+        - Acronyms
+      parameters:
+        - name: acronym
+          in: path
+          description: Name of the project
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Acronym details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AcronymDetail'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /checks/status:
     get:
       summary: Returns status of correspondent APIs
@@ -277,6 +309,21 @@ components:
       type: openIdConnect
       openIdConnectUrl: 'https://example.com/.well-known/openid-configuration'
   schemas:
+    AcronymDetail:
+      type: object
+      properties:
+        acronym:
+          type: string
+          example: MSSC
+        name:
+          type: string
+          example: Messaging Service Showcase
+        webadePermission:
+          type: boolean
+          example: true
+        webadeNrosDmsPermission:
+          type: boolean
+          example: false
     AppConfig:
       type: object
       properties:

--- a/backend/src/migrations/20200107052720-add-acronym-webade-flag-columns.js
+++ b/backend/src/migrations/20200107052720-add-acronym-webade-flag-columns.js
@@ -1,0 +1,33 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.addColumn(
+        'acronym',
+        'permissionWebade',
+        {
+          comment: 'Flag stating whether this acronym can use WebADE',
+          allowNull: false,
+          defaultValue: false,
+          type: Sequelize.BOOLEAN
+        }
+      ),
+      queryInterface.addColumn(
+        'acronym',
+        'permissionWebadeNrosDms',
+        {
+          comment: 'Flag stating whether this acronym can grant access to NROS documents through DMS',
+          allowNull: false,
+          defaultValue: false,
+          type: Sequelize.BOOLEAN
+        }
+      ),
+    ]);
+  },
+
+  down: (queryInterface) => {
+    return Promise.all([
+      queryInterface.removeColumn('acronym', 'permissionWebade'),
+      queryInterface.removeColumn('acronym', 'permissionWebadeNrosDms')
+    ]);
+  }
+};

--- a/backend/src/migrations/20200107052720-add-acronym-webade-flag-columns.js
+++ b/backend/src/migrations/20200107052720-add-acronym-webade-flag-columns.js
@@ -26,8 +26,8 @@ module.exports = {
 
   down: (queryInterface) => {
     return Promise.all([
-      queryInterface.removeColumn('acronym', 'permissionWebade'),
-      queryInterface.removeColumn('acronym', 'permissionWebadeNrosDms')
+      queryInterface.removeColumn('acronym', 'permissionWebadeNrosDms'),
+      queryInterface.removeColumn('acronym', 'permissionWebade')
     ]);
   }
 };

--- a/backend/src/models/acronym.js
+++ b/backend/src/models/acronym.js
@@ -22,6 +22,16 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       comment: 'Name of the application acronym',
       type: DataTypes.STRING(64)
+    },
+    permissionWebade: {
+      allowNull: false,
+      comment: 'Flag stating whether this acronym can use WebADE',
+      type: DataTypes.BOOLEAN
+    },
+    permissionWebadeNrosDms: {
+      allowNull: false,
+      comment: 'Flag stating whether this acronym can grant access to NROS documents through DMS',
+      type: DataTypes.BOOLEAN
     }
   }, {
     comment: 'List of all valid application acronyms',

--- a/backend/src/routes/v1.js
+++ b/backend/src/routes/v1.js
@@ -5,6 +5,7 @@ const passport = require('passport');
 const webAdeRouter = require('./v1/webAde');
 const checksRouter = require('./v1/checks');
 const keyCloakRouter = require('./v1/keyCloak');
+const acronymsRouter = require('./v1/acronyms');
 
 // Base v1 Responder
 router.get('/', (_req, res) => {
@@ -43,5 +44,11 @@ router.use('/keyCloak', passport.authenticate('jwt', {
 router.use('/checks', passport.authenticate('jwt', {
   session: false
 }), checksRouter);
+
+// Acronyms
+router.use('/acronyms', passport.authenticate('jwt', {
+  session: false
+}), acronymsRouter);
+
 
 module.exports = router;

--- a/backend/src/routes/v1/acronyms.js
+++ b/backend/src/routes/v1/acronyms.js
@@ -1,0 +1,34 @@
+const log = require('npmlog');
+
+const webAde = require('express').Router();
+const utils = require('../../components/utils');
+const acronymComponent = require('../../components/acronyms');
+
+// fetches the acronym details
+webAde.get('/:appAcronym', [
+], async (req, res) => {
+  // Check for required permissions. Can only fetch details for the acronyms you are associated with
+  const permissionErr = utils.checkAcronymPermission(req.user.jwt, req.params.appAcronym);
+  if (permissionErr) {
+    return res.status(403).json({
+      message: permissionErr
+    });
+  }
+
+  try {
+    const response = await acronymComponent.getAcronym(req.params.appAcronym);
+    if (response) {
+      return res.status(200).json(response);
+    } else {
+      return res.status(404).end();
+    }
+  } catch (error) {
+    log.error(error);
+    res.status(500).json({
+      message: error.message
+    });
+    return res;
+  }
+});
+
+module.exports = webAde;

--- a/backend/src/routes/v1/keyCloak.js
+++ b/backend/src/routes/v1/keyCloak.js
@@ -23,8 +23,6 @@ keyCloak.post('/configForm', [
 ], async (req, res) => {
   // Validate for Bad Requests
   const errors = validationResult(req);
-  console.log(req.body);
-  console.log(errors);
   if (!errors.isEmpty()) {
     return res.status(400).json({
       errors: errors.array(),

--- a/backend/src/routes/v1/webAde.js
+++ b/backend/src/routes/v1/webAde.js
@@ -12,7 +12,6 @@ const {
 // fetches the app config json for a acronym in a specified env
 webAde.get('/:webAdeEnv/:appAcronym/appConfig', [
 ], async (req, res) => {
-
   // TODO: a lot of this role checking is duplicate, but as we will be moving acronym management to the DB soon all this will need to be refactored anyways
 
   // Check for required permissions. Can only fetch cfgs for the acronyms you are associated with
@@ -176,24 +175,18 @@ webAde.post('/configForm', [
       message: 'Validation failed'
     });
   }
-
-  // Check for required permission
-  let acronyms = [];
-  const roles = req.user.jwt.realm_access.roles;
-  if (typeof roles === 'object' && roles instanceof Array) {
-    acronyms = utils.filterAppAcronymRoles(roles);
-  }
-
   const {
     configForm,
     passwordPublicKey: publicKey
   } = req.body;
 
-  const appAcronym = configForm.applicationAcronym;
-  if (!acronyms.includes(configForm.applicationAcronym)) {
+  // Check if this is allowed, return the error message if not
+  const err = utils.checkWebAdePostPermissions(req.user.jwt, configForm);
+  if(err) {
     return res.status(403).json({
-      message: `User lacks permission for '${appAcronym}' acronym`
+      message: err
     });
+
   }
 
   try {

--- a/backend/tests/unit/components/fixtures/configForm.json
+++ b/backend/tests/unit/components/fixtures/configForm.json
@@ -1,0 +1,11 @@
+{
+  "applicationAcronym": "WORG",
+  "applicationName": "Test application",
+  "applicationDescription": "Description for the test application",
+  "commonServices": [
+    "CMSG",
+    "DMS"
+  ],
+  "clientEnvironment": "INT",
+  "passwordPublicKey": "ABC"
+}

--- a/backend/tests/unit/components/fixtures/token.json
+++ b/backend/tests/unit/components/fixtures/token.json
@@ -1,0 +1,66 @@
+{
+  "jti": "20c32131-4bca-4c65-95e8-2774861c0eda",
+  "exp": 1578010912,
+  "nbf": 0,
+  "iat": 1578010852,
+  "iss": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/vehizw2t",
+  "aud": [
+    "realm-management",
+    "account"
+  ],
+  "sub": "4b5d0a2f-63a0-4c18-9d70-753648b8e7a9",
+  "typ": "Bearer",
+  "azp": "getok",
+  "nonce": "7308177a-712c-46ab-bdaa-aa2683aee8c7",
+  "auth_time": 1578010851,
+  "session_state": "bb26a935-c6ba-4f50-9261-2f4d7171c6d1",
+  "acr": "1",
+  "realm_access": {
+    "roles": [
+      "WORG",
+      "MSSC",
+      "WEBADE_CFG_READ",
+      "offline_access",
+      "uma_authorization",
+      "WEBADE_CFG_READ_ALL"
+    ]
+  },
+  "resource_access": {
+    "realm-management": {
+      "roles": [
+        "view-realm",
+        "view-identity-providers",
+        "manage-identity-providers",
+        "impersonation",
+        "realm-admin",
+        "create-client",
+        "manage-users",
+        "query-realms",
+        "view-authorization",
+        "query-clients",
+        "query-users",
+        "manage-events",
+        "manage-realm",
+        "view-events",
+        "view-users",
+        "view-clients",
+        "manage-authorization",
+        "manage-clients",
+        "query-groups"
+      ]
+    },
+    "account": {
+      "roles": [
+        "manage-account",
+        "manage-account-links",
+        "view-profile"
+      ]
+    }
+  },
+  "scope": "openid offline_access",
+  "name": "Jane Smith",
+  "preferred_username": "Jane@idir",
+  "given_name": "Jane",
+  "family_name": "Smith",
+  "email": "Jane.Smith@gov.bc.ca"
+}

--- a/backend/tests/unit/components/fixtures/token.json
+++ b/backend/tests/unit/components/fixtures/token.json
@@ -26,29 +26,6 @@
     ]
   },
   "resource_access": {
-    "realm-management": {
-      "roles": [
-        "view-realm",
-        "view-identity-providers",
-        "manage-identity-providers",
-        "impersonation",
-        "realm-admin",
-        "create-client",
-        "manage-users",
-        "query-realms",
-        "view-authorization",
-        "query-clients",
-        "query-users",
-        "manage-events",
-        "manage-realm",
-        "view-events",
-        "view-users",
-        "view-clients",
-        "manage-authorization",
-        "manage-clients",
-        "query-groups"
-      ]
-    },
     "account": {
       "roles": [
         "manage-account",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
To suppor the following tickets (to add restrictions to who can perform WebADE actions in GETOK), adding an acronyms endpoint so the FE can fetch acronym details (including new WebADE permission flags) from the database.
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-439
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-438


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

New endpoint added so that frontend can get the app acronym details and access any flags/names/etc stored in the GETOK database.

Since we need to be able to secure the webade permissions at a *per-acronym* level, this is not supported in our current Keycloak model as the token has no information about the groups that these roles would be applied to.
This necessitated us adding flags at the acronym level in the database, which is the direction we want to be migrating to eventually anyways.