### PR TITLE
More webade restriction, some fixes, some unit tests

### DIFF
--- a/backend/src/components/appConfig.js
+++ b/backend/src/components/appConfig.js
@@ -165,10 +165,10 @@ const appConfig = {
   },
 
   /**
-  * Return a permission error if the user is not allowed to do this. Undefined if no error
-  * @param {string} token - the user's token
-  * @param {string} applicationAcronym - The app specifier.
-  */
+   * Return a permission error if the user is not allowed to do this. Undefined if no error
+   * @param {string} token - the user's token
+   * @param {string} applicationAcronym - The app specifier.
+   */
   getPermissionError: async (token, configForm) => {
     const acronym = configForm.applicationAcronym;
     if (!acronym) {

--- a/backend/src/components/appConfig.js
+++ b/backend/src/components/appConfig.js
@@ -3,8 +3,8 @@ const config = require('config');
 const log = require('npmlog');
 
 const {
-  lifecycleService,
-  acronymService
+  acronymService,
+  lifecycleService
 } = require('../services');
 const utils = require('./utils');
 const permissionHelper = require('./permissionHelpers');

--- a/backend/src/components/appConfig.js
+++ b/backend/src/components/appConfig.js
@@ -3,9 +3,11 @@ const config = require('config');
 const log = require('npmlog');
 
 const {
-  lifecycleService
+  lifecycleService,
+  acronymService
 } = require('../services');
 const utils = require('./utils');
+const permissionHelper = require('./permissionHelpers');
 
 const appConfig = {
   // Constructs a WebADE Application Configuration based on the request body
@@ -160,6 +162,35 @@ const appConfig = {
         throw new Error(`WebADE ${path} returned an error. ${JSON.stringify(error.response.data)}`);
       }
     }
+  },
+
+  /**
+  * Return a permission error if the user is not allowed to do this. Undefined if no error
+  * @param {string} token - the user's token
+  * @param {string} applicationAcronym - The app specifier.
+  */
+  getPermissionError: async (token, configForm) => {
+    const acronym = configForm.applicationAcronym;
+    if (!acronym) {
+      const errMsg = 'No app acronym determined during permission check';
+      log.error('getPermissionError', errMsg);
+      return errMsg;
+    }
+
+    // Get the stored app acronym details from the getok db
+    const acronymDetails = await acronymService.find(acronym);
+    if (!acronymDetails) {
+      return `Acronym ${acronym} could not be found in GETOK database`;
+    }
+
+    // Figure out what permissions are required based on the request
+    const desiredUserRoles = ['WEBADE_PERMISSION'];
+    if (configForm.commonServices && configForm.commonServices.includes('nros-dms')) {
+      desiredUserRoles.push('WEBADE_PERMISSION_NROS_DMS');
+    }
+
+    // Can this call be made?
+    return permissionHelper.checkWebAdePostPermissions(token, configForm, acronymDetails, desiredUserRoles);
   },
 
   /**

--- a/backend/src/components/auth.js
+++ b/backend/src/components/auth.js
@@ -9,6 +9,7 @@ const {
   userService
 } = require('../services');
 const utils = require('./utils');
+const permissionHelpers = require('./permissionHelpers');
 
 const auth = {
   // Check if JWT Access Token has expired
@@ -103,7 +104,7 @@ const auth = {
       // Add keycloak authorized acronyms if they don't already exist
       let acronymList = [];
       if (typeof roles === 'object' && roles instanceof Array) {
-        acronymList = utils.filterAppAcronymRoles(roles);
+        acronymList = permissionHelpers.filterAppAcronymRoles(roles);
       }
       await acronymService.findOrCreateList(acronymList);
 

--- a/backend/src/components/auth.js
+++ b/backend/src/components/auth.js
@@ -8,8 +8,8 @@ const {
   acronymService,
   userService
 } = require('../services');
-const utils = require('./utils');
 const permissionHelpers = require('./permissionHelpers');
+const utils = require('./utils');
 
 const auth = {
   // Check if JWT Access Token has expired

--- a/backend/src/components/permissionHelpers.js
+++ b/backend/src/components/permissionHelpers.js
@@ -26,7 +26,7 @@ const permissionHelpers = {
     // Do they have access to the Acronym they are trying to POST
     const appAcronym = applicationAcronym;
     if (!acronyms.includes(applicationAcronym)) {
-      log.verbose(`User not authorized for acronym ${applicationAcronym}. Token: ${utils.prettyStringify(token)}`);
+      log.verbose('checkAcronymPermission', `User not authorized for acronym ${applicationAcronym}. Token: ${utils.prettyStringify(token)}`);
       return `User lacks permission for '${appAcronym}' acronym`;
     }
   },

--- a/backend/src/components/permissionHelpers.js
+++ b/backend/src/components/permissionHelpers.js
@@ -1,0 +1,73 @@
+const log = require('npmlog');
+const utils = require('./utils');
+
+
+const permissionHelpers = {
+  // TODO: this is likely soon to be refactored out, as we will be pulling acronyms from the DB, not from access roles
+  // Returns only app acronym based roles
+  filterAppAcronymRoles: roles => roles.filter(role => !role.match(/offline_access|uma_authorization|WEBADE_CFG_READ|WEBADE_CFG_READ_ALL/)),
+
+  /**
+  * Is this call allowed to be made for the acronym it's being made for?
+  * @param {string} token - The user's token from the request.
+  * @param {string} acronym - The app acronym.
+  * @returns {string} Error Message - Undefined if permitted, a string of the error message to return if not permitted.
+  */
+  checkAcronymPermission: (token, applicationAcronym) => {
+    // TODO: a lot of this role checking is duplicate, but as we will be moving acronym management to the DB soon all this will need to be refactored anyways
+
+    // Get Acronyms from user token
+    let acronyms = [];
+    const roles = token.realm_access.roles;
+    if (typeof roles === 'object' && roles instanceof Array) {
+      acronyms = permissionHelpers.filterAppAcronymRoles(roles);
+    }
+
+    // Do they have access to the Acronym they are trying to POST
+    const appAcronym = applicationAcronym;
+    if (!acronyms.includes(applicationAcronym)) {
+      log.verbose(`User not authorized for acronym ${applicationAcronym}. Token: ${utils.prettyStringify(token)}`);
+      return `User lacks permission for '${appAcronym}' acronym`;
+    }
+  },
+
+  /**
+  * Is this call allowed to post the WebADE config details?
+  * @param {string} token - The user's token from the request.
+  * @param {string} configForm - The form posted to the post enpoint.
+  * @param {string} acronymData - The acronym details from the getok db.
+  * @param {string} desiredUserRoles - Specific user permissions that are needed for the operation to check.
+  * @returns {string} Error Message - Undefined if permitted, a string of the error message to return if not permitted.
+  */
+  checkWebAdePostPermissions: (token, configForm, acronymData, desiredUserRoles = []) => {
+    // Do they have access to the Acronym they are trying to POST
+    let acronymAccessError = permissionHelpers.checkAcronymPermission(token, configForm.applicationAcronym);
+    if (acronymAccessError) {
+      return acronymAccessError;
+    }
+
+    // Do they have the specified scopes
+    let roleError = undefined;
+    desiredUserRoles.forEach((role) => {
+      if (!token.realm_access.roles.includes(role)) {
+        roleError = `User is not permitted to submit WebADE config, missing role ${role}`;
+        return;
+      }
+    });
+    if(roleError) {
+      return roleError;
+    }
+
+    // Is this acronym allowed to post webade
+    if (!acronymData.permissionWebade) {
+      return `Acronym '${acronymData.acronym}' is not permitted to submit WebADE configs`;
+    }
+
+    // If trying to do it, is this acronym allowed special access to NROS DMs
+    if (desiredUserRoles.includes('WEBADE_PERMISSION_NROS_DMS') && !acronymData.permissionWebadeNrosDms) {
+      return `Acronym '${acronymData.acronym}' is not permitted special access to NROS DMS`;
+    }
+  }
+};
+
+module.exports = permissionHelpers;

--- a/backend/src/components/utils.js
+++ b/backend/src/components/utils.js
@@ -69,10 +69,6 @@ const utils = {
   // Returns a string in Pascal Case
   toPascalCase: str => str.toLowerCase().replace(/\b\w/g, t => t.toUpperCase()),
 
-  // TODO: this is likely soon to be refactored out, as we will be pulling acronyms from the DB, not from access roles
-  // Returns only app acronym based roles
-  filterAppAcronymRoles: roles => roles.filter(role => !role.match(/offline_access|uma_authorization|WEBADE_CFG_READ|WEBADE_CFG_READ_ALL/)),
-
   /**
   * From the big list of webade configs, return all APPLICATION preferences that match the search critera in the name that are not masked
   * @param {string} webadeConfigsList - The array of all the webade configs.
@@ -133,44 +129,6 @@ const utils = {
     } else {
       log.error('filterWebAdeDependencies', 'Error in supplied webade configuration list');
       throw new Error('Unable to fetch dependencies - Error in supplied webade configuration list');
-    }
-  },
-
-  /**
-  * Is this call allowed to be made for the acronym it's being made for?
-  * @param {string} token - The user's token from the request.
-  * @param {string} acronym - The app acronym.
-  * @returns {string} Error Message - Undefined if permitted, a string of the error message to return if not permitted.
-  */
-  checkAcronymPermission: (token, applicationAcronym) => {
-    // TODO: a lot of this role checking is duplicate, but as we will be moving acronym management to the DB soon all this will need to be refactored anyways
-
-    // Get Acronyms from user token
-    let acronyms = [];
-    const roles = token.realm_access.roles;
-    if (typeof roles === 'object' && roles instanceof Array) {
-      acronyms = utils.filterAppAcronymRoles(roles);
-    }
-
-    // Do they have access to the Acronym they are trying to POST
-    const appAcronym = applicationAcronym;
-    if (!acronyms.includes(applicationAcronym)) {
-      log.verbose(`User not authorized for acronym ${applicationAcronym}. Token: ${utils.prettyStringify(token)}`);
-      return `User lacks permission for '${appAcronym}' acronym`;
-    }
-  },
-
-  /**
-  * Is this call allowed to post the WebADE config details?
-  * @param {string} token - The user's token from the request.
-  * @param {string} configForm - The form posted to the post enpoint.
-  * @returns {string} Error Message - Undefined if permitted, a string of the error message to return if not permitted.
-  */
-  checkWebAdePostPermissions: (token, configForm) => {
-    // Do they have access to the Acronym they are trying to POST
-    const acronymAccessError = utils.checkAcronymPermission(token, configForm.applicationAcronym);
-    if (acronymAccessError) {
-      return acronymAccessError;
     }
   }
 };

--- a/backend/src/components/utils.js
+++ b/backend/src/components/utils.js
@@ -75,7 +75,8 @@ const utils = {
   * @param {string} searchCriteria - The regex to search through the preference name on.
   */
   filterForInsecurePrefs: (webadeConfigsList, searchCriteria) => {
-    if (webadeConfigsList) {
+    if (webadeConfigsList && webadeConfigsList.applicationConfigurations
+      && webadeConfigsList.applicationConfigurations.length) {
       // From all the configs, get out the preferences
       // filter on the search criteria and the sensitiveDataInd field
       const regex = new RegExp(searchCriteria, 'gi');

--- a/backend/src/docs/v1.api-spec.yaml
+++ b/backend/src/docs/v1.api-spec.yaml
@@ -428,7 +428,7 @@ components:
           type: array
           items:
             type: string
-            example: CMSG
+            example: cmsg
           description: An array of applicationAcronyms
         passwordPublicKey:
           type: string

--- a/backend/src/routes/v1/acronyms.js
+++ b/backend/src/routes/v1/acronyms.js
@@ -1,14 +1,14 @@
 const log = require('npmlog');
 
 const webAde = require('express').Router();
-const utils = require('../../components/utils');
+const permissionHelpers = require('../../components/permissionHelpers');
 const acronymComponent = require('../../components/acronyms');
 
 // fetches the acronym details
 webAde.get('/:appAcronym', [
 ], async (req, res) => {
   // Check for required permissions. Can only fetch details for the acronyms you are associated with
-  const permissionErr = utils.checkAcronymPermission(req.user.jwt, req.params.appAcronym);
+  const permissionErr = permissionHelpers.checkAcronymPermission(req.user.jwt, req.params.appAcronym);
   if (permissionErr) {
     return res.status(403).json({
       message: permissionErr

--- a/backend/src/routes/v1/webAde.js
+++ b/backend/src/routes/v1/webAde.js
@@ -160,7 +160,7 @@ webAde.post('/configForm', [
   } = req.body;
 
   // Check if this is allowed, return the error message if not
-  const err = appConfigComponent.getPermissionError(req.user.jwt, configForm);
+  const err = await appConfigComponent.getPermissionError(req.user.jwt, configForm);
   if (err) {
     log.debug('/configForm', `No permission to Post WebADE config: ${err}`);
     return res.status(403).json({

--- a/backend/src/routes/v1/webAde.js
+++ b/backend/src/routes/v1/webAde.js
@@ -2,6 +2,7 @@ const log = require('npmlog');
 
 const webAde = require('express').Router();
 const utils = require('../../components/utils');
+const permissionHelpers = require('../../components/permissionHelpers');
 const appConfigComponent = require('../../components/appConfig');
 
 const {
@@ -160,7 +161,7 @@ webAde.post('/configForm', [
   } = req.body;
 
   // Check if this is allowed, return the error message if not
-  const err = utils.checkWebAdePostPermissions(req.user.jwt, configForm);
+  const err = permissionHelpers.checkWebAdePostPermissions(req.user.jwt, configForm);
   if (err) {
     return res.status(403).json({
       message: err

--- a/backend/src/routes/v1/webAde.js
+++ b/backend/src/routes/v1/webAde.js
@@ -163,6 +163,7 @@ webAde.post('/configForm', [
   // Check if this is allowed, return the error message if not
   const err = permissionHelpers.checkWebAdePostPermissions(req.user.jwt, configForm);
   if (err) {
+    log.debug('/configForm', `No permission to Post WebADE config: ${err}`);
     return res.status(403).json({
       message: err
     });

--- a/backend/src/routes/v1/webAde.js
+++ b/backend/src/routes/v1/webAde.js
@@ -162,7 +162,7 @@ webAde.post('/configForm', [
   // Check if this is allowed, return the error message if not
   const err = await appConfigComponent.getPermissionError(req.user.jwt, configForm);
   if (err) {
-    log.debug('/configForm', `No permission to Post WebADE config: ${err}`);
+    log.debug('GET /configForm', `No permission to Post WebADE config: ${err}`);
     return res.status(403).json({
       message: err
     });

--- a/backend/src/routes/v1/webAde.js
+++ b/backend/src/routes/v1/webAde.js
@@ -2,7 +2,6 @@ const log = require('npmlog');
 
 const webAde = require('express').Router();
 const utils = require('../../components/utils');
-const permissionHelpers = require('../../components/permissionHelpers');
 const appConfigComponent = require('../../components/appConfig');
 
 const {
@@ -161,7 +160,7 @@ webAde.post('/configForm', [
   } = req.body;
 
   // Check if this is allowed, return the error message if not
-  const err = permissionHelpers.checkWebAdePostPermissions(req.user.jwt, configForm);
+  const err = appConfigComponent.getPermissionError(req.user.jwt, configForm);
   if (err) {
     log.debug('/configForm', `No permission to Post WebADE config: ${err}`);
     return res.status(403).json({

--- a/backend/src/routes/v1/webAde.js
+++ b/backend/src/routes/v1/webAde.js
@@ -12,23 +12,13 @@ const {
 // fetches the app config json for a acronym in a specified env
 webAde.get('/:webAdeEnv/:appAcronym/appConfig', [
 ], async (req, res) => {
-  // TODO: a lot of this role checking is duplicate, but as we will be moving acronym management to the DB soon all this will need to be refactored anyways
-
   // Check for required permissions. Can only fetch cfgs for the acronyms you are associated with
   // If the user has "WEBADE_CFG_READ_ALL" then they can get all
-  let acronyms = [];
-  const roles = req.user.jwt.realm_access.roles;
-  let hasReadAllRole = false;
-  if (typeof roles === 'object' && roles instanceof Array) {
-    acronyms = utils.filterAppAcronymRoles(roles);
-    hasReadAllRole = roles.includes('WEBADE_CFG_READ_ALL');
-  }
-
-  if (!hasReadAllRole) {
-    const appAcronym = req.params.appAcronym;
-    if (!acronyms.includes(appAcronym)) {
+  if (!req.user.jwt.realm_access.roles.includes('WEBADE_CFG_READ_ALL')) {
+    const permissionErr = utils.checkAcronymPermission(req.user.jwt, req.params.appAcronym);
+    if (permissionErr) {
       return res.status(403).json({
-        message: `User lacks permission for '${appAcronym}' acronym`
+        message: permissionErr
       });
     }
   }
@@ -52,24 +42,13 @@ webAde.get('/:webAdeEnv/:appAcronym/appConfig', [
 // fetches a list of other webade apps that are dependent on a supplied acronym in a specified env
 webAde.get('/:webAdeEnv/:appAcronym/dependencies', [
 ], async (req, res) => {
-
-  // TODO: a lot of this role checking is duplicate, but as we will be moving acronym management to the DB soon all this will need to be refactored anyways
-
   // Check for required permissions. Can only fetch cfgs for the acronyms you are associated with
   // If the user has "WEBADE_CFG_READ_ALL" then they can get all
-  let acronyms = [];
-  const roles = req.user.jwt.realm_access.roles;
-  let hasReadAllRole = false;
-  if (typeof roles === 'object' && roles instanceof Array) {
-    acronyms = utils.filterAppAcronymRoles(roles);
-    hasReadAllRole = roles.includes('WEBADE_CFG_READ_ALL');
-  }
-
-  if (!hasReadAllRole) {
-    const appAcronym = req.params.appAcronym;
-    if (!acronyms.includes(appAcronym)) {
+  if (!req.user.jwt.realm_access.roles.includes('WEBADE_CFG_READ_ALL')) {
+    const permissionErr = utils.checkAcronymPermission(req.user.jwt, req.params.appAcronym);
+    if (permissionErr) {
       return res.status(403).json({
-        message: `User lacks permission for '${appAcronym}' acronym`
+        message: permissionErr
       });
     }
   }
@@ -182,7 +161,7 @@ webAde.post('/configForm', [
 
   // Check if this is allowed, return the error message if not
   const err = utils.checkWebAdePostPermissions(req.user.jwt, configForm);
-  if(err) {
+  if (err) {
     return res.status(403).json({
       message: err
     });

--- a/backend/tests/unit/components/acronyms.spec.js
+++ b/backend/tests/unit/components/acronyms.spec.js
@@ -1,0 +1,59 @@
+const config = require('config');
+const log = require('npmlog');
+
+const acronyms = require('../../../src/components/acronyms');
+const {
+  acronymService
+} = require('../../../src/services');
+
+log.level = config.get('server.logLevel');
+
+describe('getAcronym', () => {
+  const acronymDetailFixture = require('./fixtures/acronymDetail.json');
+
+  // Spy/mock the DB access 'find' method on the acronym table
+  const spy = jest.spyOn(acronymService, 'find');
+  jest.mock('../../../src/services/acronym');
+
+  afterEach(() => {
+    spy.mockClear();
+  });
+
+  it('should return an acronym found from the mocked data adapter', async () => {
+    acronymService.find.mockResolvedValue(acronymDetailFixture);
+    const appAcr = 'WORG';
+
+    const result = await acronyms.getAcronym(appAcr);
+
+    expect(result).toBeTruthy();
+    expect(result).toEqual(acronymDetailFixture);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(appAcr);
+  });
+
+  it('should return null if the data adapter returns nothing found', async () => {
+    acronymService.find.mockResolvedValue(undefined);
+    const appAcr = 'ANY';
+
+    const result = await acronyms.getAcronym(appAcr);
+
+    expect(result).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(appAcr);
+  });
+
+  it('should error if no acronym passed to it', async () => {
+    acronymService.find.mockResolvedValue(acronymDetailFixture);
+
+    await expect(acronyms.getAcronym(undefined)).rejects.toThrow();
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should re-throw if no catching an error from the data layer', async () => {
+    acronymService.find.mockImplementation(() => {
+      throw new Error();
+    });
+
+    await expect(acronyms.getAcronym(undefined)).rejects.toThrow();
+  });
+});

--- a/backend/tests/unit/components/appConfig.spec.js
+++ b/backend/tests/unit/components/appConfig.spec.js
@@ -7,8 +7,8 @@ const MockAdapter = require('axios-mock-adapter');
 
 const appConfig = require('../../../src/components/appConfig');
 const {
-  lifecycleService,
-  acronymService
+  acronymService,
+  lifecycleService
 } = require('../../../src/services');
 const utils = require('../../../src/components/utils');
 
@@ -247,9 +247,9 @@ describe('getAppConfig', () => {
 });
 
 describe('getPermissionError', () => {
-  const tokenFixture = require('./fixtures/token.json');
   const acronymDetailFixture = require('./fixtures/acronymDetail.json');
   const configFormFixture = require('./fixtures/configForm.json');
+  const tokenFixture = require('./fixtures/token.json');
 
   // Spy/mock the DB access 'find' method on the acronym table
   const spy = jest.spyOn(acronymService, 'find');

--- a/backend/tests/unit/components/appConfig.spec.js
+++ b/backend/tests/unit/components/appConfig.spec.js
@@ -7,7 +7,8 @@ const MockAdapter = require('axios-mock-adapter');
 
 const appConfig = require('../../../src/components/appConfig');
 const {
-  lifecycleService
+  lifecycleService,
+  acronymService
 } = require('../../../src/services');
 const utils = require('../../../src/components/utils');
 
@@ -243,4 +244,59 @@ describe('getAppConfig', () => {
       }
     });
   });
+});
+
+describe('getPermissionError', () => {
+  const tokenFixture = require('./fixtures/token.json');
+  const acronymDetailFixture = require('./fixtures/acronymDetail.json');
+  const configFormFixture = require('./fixtures/configForm.json');
+
+  // Spy/mock the DB access 'find' method on the acronym table
+  const spy = jest.spyOn(acronymService, 'find');
+  jest.mock('../../../src/services/acronym');
+
+  afterEach(() => {
+    spy.mockClear();
+  });
+
+  it('should return no error message if permissions are all good', async () => {
+    acronymService.find.mockResolvedValue(acronymDetailFixture);
+
+    const tokenCopy = JSON.parse(JSON.stringify(tokenFixture));
+    tokenCopy.realm_access.roles.push(...['WEBADE_PERMISSION', 'WEBADE_PERMISSION_NROS_DMS']);
+
+    const configFormCopy = JSON.parse(JSON.stringify(configFormFixture));
+    configFormCopy.commonServices.push('nros-dms');
+
+    const result = await appConfig.getPermissionError(tokenCopy, configFormCopy);
+
+    expect(result).toBeUndefined();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return an error if lacking permissions', async () => {
+    acronymService.find.mockResolvedValue(acronymDetailFixture);
+
+    const result = await appConfig.getPermissionError(tokenFixture, configFormFixture);
+
+    expect(result).toEqual('User is not permitted to submit WebADE config, missing role WEBADE_PERMISSION');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return an error message if acronym cannot be found', async () => {
+    acronymService.find.mockResolvedValue(undefined);
+
+    const result = await appConfig.getPermissionError(tokenFixture, configFormFixture);
+
+    expect(result).toEqual('Acronym WORG could not be found in GETOK database');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return an error message if no acronym is supplied', async () => {
+    const result = await appConfig.getPermissionError(null, { applicationAcronym: undefined });
+
+    expect(result).toEqual('No app acronym determined during permission check');
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
 });

--- a/backend/tests/unit/components/fixtures/acronymDetail.json
+++ b/backend/tests/unit/components/fixtures/acronymDetail.json
@@ -1,0 +1,10 @@
+{
+  "acronymId": "a8cbfc84-70a4-402c-921d-104f033a6861",
+  "acronym": "WORG",
+  "name": "Document Generation",
+  "permissionWebade": true,
+  "permissionWebadeNrosDms": true,
+  "createdAt": "2020-01-07T18:33:49.656Z",
+  "updatedAt": "2020-01-07T18:33:49.656Z",
+  "deletedAt": null
+}

--- a/backend/tests/unit/components/fixtures/configForm.json
+++ b/backend/tests/unit/components/fixtures/configForm.json
@@ -3,8 +3,8 @@
   "applicationName": "Test application",
   "applicationDescription": "Description for the test application",
   "commonServices": [
-    "CMSG",
-    "DMS"
+    "cmsg",
+    "dms"
   ],
   "clientEnvironment": "INT",
   "passwordPublicKey": "ABC"

--- a/backend/tests/unit/components/permissionHelpers.spec.js
+++ b/backend/tests/unit/components/permissionHelpers.spec.js
@@ -3,6 +3,10 @@ const log = require('npmlog');
 
 const permissionHelpers = require('../../../src/components/permissionHelpers');
 
+const acronymDetail = require('./fixtures/acronymDetail.json');
+const configForm = require('./fixtures/configForm.json');
+const sampleToken = require('./fixtures/token.json');
+
 log.level = config.get('server.logLevel');
 
 describe('filterAppAcronymRoles', () => {
@@ -21,11 +25,6 @@ describe('filterAppAcronymRoles', () => {
     expect(result).toHaveLength(0);
   });
 });
-
-const configForm = require('./fixtures/configForm.json');
-const sampleToken = require('./fixtures/token.json');
-const acronymDetail = require('./fixtures/acronymDetail.json');
-
 
 describe('checkAcronymPermission', () => {
   it('should return no error when user has permission for acronym', async () => {
@@ -104,7 +103,7 @@ describe('checkWebAdePostPermissions', () => {
     expect(result).toEqual('Acronym \'WORG\' is not permitted to submit WebADE configs');
   });
 
-  it('should return an error when acronym is not allowed to do special NROS DMS', async () => {
+  it('should return an error when acronym is not allowed to do special NROS DMS', () => {
     // Set acronym detail to not allow webade
     const tokenCopy = JSON.parse(JSON.stringify(sampleToken));
     tokenCopy.realm_access.roles.push(...['WEBADE_PERMISSION', 'WEBADE_PERMISSION_NROS_DMS']);

--- a/backend/tests/unit/components/permissionHelpers.spec.js
+++ b/backend/tests/unit/components/permissionHelpers.spec.js
@@ -1,0 +1,116 @@
+const config = require('config');
+const log = require('npmlog');
+
+const permissionHelpers = require('../../../src/components/permissionHelpers');
+
+log.level = config.get('server.logLevel');
+
+describe('filterAppAcronymRoles', () => {
+  it('should return the filtered acronym list', () => {
+    const roles = ['offline_access', 'uma_authorization', 'WEBADE_CFG_READ', 'WEBADE_CFG_READ_ALL', 'DOMO', 'MSSC'];
+    const result = permissionHelpers.filterAppAcronymRoles(roles);
+
+    expect(result).toBeTruthy();
+    expect(result).toHaveLength(2);
+  });
+
+  it('should handle an empty array', () => {
+    const roles = [];
+    const result = permissionHelpers.filterAppAcronymRoles(roles);
+    expect(result).toBeTruthy();
+    expect(result).toHaveLength(0);
+  });
+});
+
+const configForm = require('./fixtures/configForm.json');
+const sampleToken = require('./fixtures/token.json');
+const acronymDetail = require('./fixtures/acronymDetail.json');
+
+
+describe('checkAcronymPermission', () => {
+  it('should return no error when user has permission for acronym', async () => {
+    // Token has a WORG scope
+    const result = permissionHelpers.checkAcronymPermission(sampleToken, 'WORG');
+    expect(result).toBeUndefined();
+  });
+
+  it('should return an error when user does not have permission for acronym', async () => {
+    // oken has no scope for ABCD
+    const result = permissionHelpers.checkAcronymPermission(sampleToken, 'ABCD');
+    expect(result).toEqual('User lacks permission for \'ABCD\' acronym');
+  });
+
+  it('should return an error when user has no acronym permissions', async () => {
+    // Token has no roles
+    const tokenCopy = JSON.parse(JSON.stringify(sampleToken));
+    tokenCopy.realm_access.roles = [];
+    const result = permissionHelpers.checkAcronymPermission(tokenCopy, 'WORG');
+    expect(result).toEqual('User lacks permission for \'WORG\' acronym');
+  });
+
+  it('should return an error when the token has a non-array roles', async () => {
+    // Token has no roles
+    const tokenCopy = JSON.parse(JSON.stringify(sampleToken));
+    tokenCopy.realm_access.roles = 'SOMETHING_WRONG';
+    const result = permissionHelpers.checkAcronymPermission(tokenCopy, 'WORG');
+    expect(result).toEqual('User lacks permission for \'WORG\' acronym');
+  });
+});
+
+describe('checkWebAdePostPermissions', () => {
+  it('should return no error when user has permission for acrony and acronym is allowed', async () => {
+    // ConfigForm is for WORG, and token has a WORG scope, acronym WORG has true for webade
+    const result = permissionHelpers.checkWebAdePostPermissions(sampleToken, configForm, acronymDetail);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return no error when user has both special scopes', async () => {
+    // ConfigForm is for WORG, and token has a WORG scope, acronym WORG has true for webade
+    const tokenCopy = JSON.parse(JSON.stringify(sampleToken));
+    tokenCopy.realm_access.roles.push(...['WEBADE_PERMISSION', 'WEBADE_PERMISSION_NROS_DMS']);
+    const result = permissionHelpers.checkWebAdePostPermissions(tokenCopy, configForm, acronymDetail, ['WEBADE_PERMISSION', 'WEBADE_PERMISSION_NROS_DMS']);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return an error when user does not have permission for acronym', async () => {
+    // ConfigForm is for ABCD, and token has no scope for that
+    const cfgCopy = JSON.parse(JSON.stringify(configForm));
+    cfgCopy.applicationAcronym = 'ABCD';
+    const result = permissionHelpers.checkWebAdePostPermissions(sampleToken, cfgCopy, acronymDetail);
+    expect(result).toEqual('User lacks permission for \'ABCD\' acronym');
+  });
+
+  it('should return an error when user has no acronym permissions', async () => {
+    // ConfigForm is for ABCD, and token has no scope for that
+    const tokenCopy = JSON.parse(JSON.stringify(sampleToken));
+    tokenCopy.realm_access.roles = [];
+    const result = permissionHelpers.checkWebAdePostPermissions(tokenCopy, configForm, acronymDetail);
+    expect(result).toEqual('User lacks permission for \'WORG\' acronym');
+  });
+
+  it('should return no error when user lacks a desired scope', async () => {
+    // Token is missing WEBADE_PERMISSION_NROS_DMS, and that is required for this operation
+    const tokenCopy = JSON.parse(JSON.stringify(sampleToken));
+    tokenCopy.realm_access.roles.push('WEBADE_PERMISSION');
+    const result = permissionHelpers.checkWebAdePostPermissions(tokenCopy, configForm, acronymDetail, ['WEBADE_PERMISSION', 'WEBADE_PERMISSION_NROS_DMS']);
+    expect(result).toEqual('User is not permitted to submit WebADE config, missing role WEBADE_PERMISSION_NROS_DMS');
+  });
+
+  it('should return an error when acronym is not allowed to use webADE', async () => {
+    // Set acronym detail to not allow webade
+    const adCopy = JSON.parse(JSON.stringify(acronymDetail));
+    adCopy.permissionWebade = false;
+    const result = permissionHelpers.checkWebAdePostPermissions(sampleToken, configForm, adCopy);
+    expect(result).toEqual('Acronym \'WORG\' is not permitted to submit WebADE configs');
+  });
+
+  it('should return an error when acronym is not allowed to do special NROS DMS', async () => {
+    // Set acronym detail to not allow webade
+    const tokenCopy = JSON.parse(JSON.stringify(sampleToken));
+    tokenCopy.realm_access.roles.push(...['WEBADE_PERMISSION', 'WEBADE_PERMISSION_NROS_DMS']);
+    const adCopy = JSON.parse(JSON.stringify(acronymDetail));
+    adCopy.permissionWebadeNrosDms = false;
+    const result = permissionHelpers.checkWebAdePostPermissions(tokenCopy, configForm, adCopy, ['WEBADE_PERMISSION', 'WEBADE_PERMISSION_NROS_DMS']);
+    expect(result).toEqual('Acronym \'WORG\' is not permitted special access to NROS DMS');
+  });
+});

--- a/backend/tests/unit/components/permissionHelpers.spec.js
+++ b/backend/tests/unit/components/permissionHelpers.spec.js
@@ -113,4 +113,9 @@ describe('checkWebAdePostPermissions', () => {
     const result = permissionHelpers.checkWebAdePostPermissions(tokenCopy, configForm, adCopy, ['WEBADE_PERMISSION', 'WEBADE_PERMISSION_NROS_DMS']);
     expect(result).toEqual('Acronym \'WORG\' is not permitted special access to NROS DMS');
   });
+
+  it('should return a generic error when an error occurs checking', async () => {
+    const result = permissionHelpers.checkWebAdePostPermissions(sampleToken, configForm, undefined);
+    expect(result).toEqual('Failed to determine permission for WebADE access');
+  });
 });

--- a/backend/tests/unit/components/utils.spec.js
+++ b/backend/tests/unit/components/utils.spec.js
@@ -195,10 +195,12 @@ describe('filterForInsecurePrefs', () => {
   });
 
   it('should not return a list of webade configs when there are 0 insecure prefs', async () => {
-
     const result = await utils.filterForInsecurePrefs(webadeList, 'password|secret');
-
     expect(result).toHaveLength(0);
+  });
+
+  it('should exception on an empty list', () => {
+    expect(() => { utils.filterForInsecurePrefs([], 'password|secret'); }).toThrow(Error);
   });
 });
 
@@ -210,5 +212,9 @@ describe('filterWebAdeDependencies', () => {
     expect(result).toBeTruthy();
     expect(result).toHaveLength(1);
     expect(result[0].applicationAcronym).toEqual('EXAMPLE2_API');
+  });
+
+  it('should throw on bad input', async () => {
+    expect(() => { utils.filterWebAdeDependencies(undefined, 'DMS'); }).toThrow(Error);
   });
 });

--- a/backend/tests/unit/components/utils.spec.js
+++ b/backend/tests/unit/components/utils.spec.js
@@ -178,24 +178,6 @@ describe('toPascalCase', () => {
   });
 });
 
-
-describe('filterAppAcronymRoles', () => {
-  it('should return the filtered acronym list', () => {
-    const roles = ['offline_access', 'uma_authorization', 'WEBADE_CFG_READ', 'WEBADE_CFG_READ_ALL', 'DOMO', 'MSSC'];
-    const result = utils.filterAppAcronymRoles(roles);
-
-    expect(result).toBeTruthy();
-    expect(result).toHaveLength(2);
-  });
-
-  it('should handle an empty array', () => {
-    const roles = [];
-    const result = utils.filterAppAcronymRoles(roles);
-    expect(result).toBeTruthy();
-    expect(result).toHaveLength(0);
-  });
-});
-
 const webadeList = require('./fixtures/webadeList.json');
 const webadeListWithInsecurePrefs = require('./fixtures/webadeListWithInsecurePrefs.json');
 
@@ -228,62 +210,5 @@ describe('filterWebAdeDependencies', () => {
     expect(result).toBeTruthy();
     expect(result).toHaveLength(1);
     expect(result[0].applicationAcronym).toEqual('EXAMPLE2_API');
-  });
-});
-
-const configForm = require('./fixtures/configForm.json');
-const sampleToken = require('./fixtures/token.json');
-
-describe('checkAcronymPermission', () => {
-  it('should return no error when user has permission for acronym', async () => {
-    // Token has a WORG scope
-    const result = utils.checkAcronymPermission(sampleToken, 'WORG');
-    expect(result).toBeUndefined();
-  });
-
-  it('should return an error when user does not have permission for acronym', async () => {
-    // oken has no scope for ABCD
-    const result = utils.checkAcronymPermission(sampleToken, 'ABCD');
-    expect(result).toEqual('User lacks permission for \'ABCD\' acronym');
-  });
-
-  it('should return an error when user has no acronym permissions', async () => {
-    // Token has no roles
-    const tokenCopy = JSON.parse(JSON.stringify(sampleToken));
-    tokenCopy.realm_access.roles = [];
-    const result = utils.checkAcronymPermission(tokenCopy, 'WORG');
-    expect(result).toEqual('User lacks permission for \'WORG\' acronym');
-  });
-
-  it('should return an error when the token has a non-array roles', async () => {
-    // Token has no roles
-    const tokenCopy = JSON.parse(JSON.stringify(sampleToken));
-    tokenCopy.realm_access.roles = 'SOMETHING_WRONG';
-    const result = utils.checkAcronymPermission(tokenCopy, 'WORG');
-    expect(result).toEqual('User lacks permission for \'WORG\' acronym');
-  });
-});
-
-describe('checkWebAdePostPermissions', () => {
-  it('should return no error when user has permission for acronym', async () => {
-    // ConfigForm is for WORG, and token has a WORG scope
-    const result = utils.checkWebAdePostPermissions(sampleToken, configForm);
-    expect(result).toBeUndefined();
-  });
-
-  it('should return an error when user does not have permission for acronym', async () => {
-    // ConfigForm is for ABCD, and token has no scope for that
-    const cfgCopy = JSON.parse(JSON.stringify(configForm));
-    cfgCopy.applicationAcronym = 'ABCD';
-    const result = utils.checkWebAdePostPermissions(sampleToken, cfgCopy);
-    expect(result).toEqual('User lacks permission for \'ABCD\' acronym');
-  });
-
-  it('should return an error when user has no acronym permissions', async () => {
-    // ConfigForm is for ABCD, and token has no scope for that
-    const tokenCopy = JSON.parse(JSON.stringify(sampleToken));
-    tokenCopy.realm_access.roles = [];
-    const result = utils.checkWebAdePostPermissions(tokenCopy, configForm);
-    expect(result).toEqual('User lacks permission for \'WORG\' acronym');
   });
 });

--- a/frontend/src/common/apiService.js
+++ b/frontend/src/common/apiService.js
@@ -103,7 +103,7 @@ Body: ${JSON.stringify(response.data, null, 2)}`;
 
   async postConfigForm(configFormBody) {
     try {
-      const route = configFormBody.commonServiceType === CommonServiceTypes.WEBADE ? ApiRoutes.WEBADE_CONFIGFORM : ApiRoutes.KCCONFIG;
+      const route = configFormBody.configForm.commonServiceType === CommonServiceTypes.WEBADE ? ApiRoutes.WEBADE_CONFIGFORM : ApiRoutes.KCCONFIG;
       const response = await apiAxios.post(route, configFormBody, {
         headers: {
           'Content-Type': 'application/json'

--- a/frontend/src/components/ConfigForm.vue
+++ b/frontend/src/components/ConfigForm.vue
@@ -110,7 +110,7 @@
         ></v-text-field>
         <div v-if="usingWebadeConfig">
           <v-select
-            :items="commonServices.services"
+            :items="commonServices"
             label="Common Service(s) Required"
             multiple
             chips
@@ -472,6 +472,8 @@ export default {
         'configForm/setCommonServiceType',
         CommonServiceTypes.WEBADE
       );
+      // Clear any common services, they will be set by the user using the drop down if desired
+      this.userAppCfg.commonServices = [];
     },
     async setKC() {
       this.$store.commit(

--- a/frontend/src/components/ConfigForm.vue
+++ b/frontend/src/components/ConfigForm.vue
@@ -52,16 +52,18 @@
           <li v-for="item in kcServices" v-bind:key="item.name">{{item.name}}</li>
         </ul>
       </div>
-      <v-btn
-        class="ma-2"
-        color="primary"
-        @click="setWebade(); appConfigStep = 3"
-        :disabled="!hasAcronyms"
-      >
-        <v-icon left>save</v-icon>Legacy (WebADE)
-      </v-btn>
-      <br />
-      <br />
+      <div v-if="hasWebadePermission">
+        <v-btn
+          class="ma-2"
+          color="primary"
+          @click="setWebade(); appConfigStep = 3"
+          :disabled="!hasAcronyms"
+        >
+          <v-icon left>save</v-icon>Legacy (WebADE)
+        </v-btn>
+        <br />
+        <br />
+      </div>
       <v-btn text @click="appConfigStep = 1">Back</v-btn>
     </v-stepper-content>
 
@@ -431,7 +433,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters('auth', ['acronyms', 'hasAcronyms']),
+    ...mapGetters('auth', ['acronyms', 'hasAcronyms', 'hasWebadePermission']),
     ...mapGetters('configForm', [
       'appConfigAsString',
       'configFormSubmissionResult',

--- a/frontend/src/store/modules/auth.js
+++ b/frontend/src/store/modules/auth.js
@@ -6,10 +6,14 @@ export default {
   state: {
     acronyms: [],
     hasReadAllWebade: false,
+    hasWebadePermission: false,
+    hasWebadeNrosDmsPermission: false,
     isAuthenticated: localStorage.getItem('jwtToken') !== null
   },
   getters: {
     acronyms: state => state.acronyms,
+    hasWebadePermission: state => state.hasWebadePermission,
+    hasWebadeNrosDmsPermission: state => state.hasWebadeNrosDmsPermission,
     hasReadAllWebade: state => state.hasReadAllWebade,
     isAuthenticated: state => state.isAuthenticated,
     hasAcronyms: state => state.acronyms && state.acronyms.length,
@@ -24,8 +28,10 @@ export default {
 
         // TODO: this will require re-conceptualizing as acronyms will come from the DB, not the access roles in the future.
         if (typeof roles === 'object' && roles instanceof Array) {
-          state.acronyms = roles.filter(role => !role.match(/offline_access|uma_authorization|WEBADE_CFG_READ|WEBADE_CFG_READ_ALL/));
+          state.acronyms = roles.filter(role => !role.match(/offline_access|uma_authorization|WEBADE_CFG_READ|WEBADE_CFG_READ_ALL|WEBADE_PERMISSION|WEBADE_PERMISSION_NROS_DMS/));
           state.hasReadAllWebade = roles.some(role => role === 'WEBADE_CFG_READ_ALL');
+          state.hasWebadePermission = roles.some(role => role === 'WEBADE_PERMISSION');
+          state.hasWebadeNrosDmsPermission = roles.some(role => role === 'WEBADE_PERMISSION_NROS_DMS');
         } else {
           state.acronyms = [];
         }

--- a/frontend/src/store/modules/configForm.js
+++ b/frontend/src/store/modules/configForm.js
@@ -211,7 +211,7 @@ export default {
         context.commit(
           'setConfigSubmissionError',
           context.getters.usingWebadeConfig ? 'An error occurred while attempting to update the application configuration in WebADE.'
-            : 'An error occurred while attempting to create a service client in Keycloak. '
+            : 'An error occurred while attempting to create a service client in Keycloak.'
         );
       }
     },

--- a/frontend/src/store/modules/configForm.js
+++ b/frontend/src/store/modules/configForm.js
@@ -176,6 +176,7 @@ export default {
   },
   actions: {
     async submitConfigForm(context) {
+
       context.commit('setConfigSubmissionInProgress');
 
       const uniqueSeed =
@@ -209,8 +210,8 @@ export default {
       } catch (error) {
         context.commit(
           'setConfigSubmissionError',
-          context.state.commonServiceType === CommonServiceTypes.WEBADE ? 'An error occurred while attempting to update the application configuration in WebADE.'
-            : 'An error occurred while attempting to create a service client in Keycloak.'
+          context.getters.usingWebadeConfig ? 'An error occurred while attempting to update the application configuration in WebADE.'
+            : 'An error occurred while attempting to create a service client in Keycloak. '
         );
       }
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Hide WebADE button on the UI if you don't have the role.
If you have WEBADE_PERMISSION the button will show, but the API call will fail as it checks the acronym in the database for the special flag set.
More UI changes to this coming as part of an issue in this sprint.

Some WebADE function was broken in a previous PR, fixes.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

 Bug fix (non-breaking change which fixes an issue) 
 New feature (non-breaking change which adds functionality) 
<!-- Documentation (non-breaking change with enhancements to documentation) -->
 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->