### PR TITLE
Postman collections

### DIFF
--- a/frontend/public/files/cdogs.postman_collection.json
+++ b/frontend/public/files/cdogs.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "0a974d4f-dab1-4b1d-a253-be3f76d17562",
+		"_postman_id": "23a09894-70a2-4138-b39a-09552b543fd4",
 		"name": "Common Document Generation Service",
 		"description": "CDOGS - A Document Generation common service",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -18,10 +18,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "https://cdogs-master-idcqvl-dev.pathfinder.gov.bc.ca/api/v1/health/",
+									"raw": "https://cdogs-master-idcqvl-prod.pathfinder.gov.bc.ca/api/v1/health",
 									"protocol": "https",
 									"host": [
-										"cdogs-master-idcqvl-dev",
+										"cdogs-master-idcqvl-prod",
 										"pathfinder",
 										"gov",
 										"bc",
@@ -30,8 +30,7 @@
 									"path": [
 										"api",
 										"v1",
-										"health",
-										""
+										"health"
 									]
 								}
 							},
@@ -66,16 +65,17 @@
 									}
 								},
 								"url": {
-									"raw": "https://cdogs-master-idcqvl-dev.pathfinder.gov.bc.ca/v1/docGen",
+									"raw": "https://cdogs-master-idcqvl-prod.pathfinder.gov.bc.ca/api/v1/docGen",
 									"protocol": "https",
 									"host": [
-										"cdogs-master-idcqvl-dev",
+										"cdogs-master-idcqvl-prod",
 										"pathfinder",
 										"gov",
 										"bc",
 										"ca"
 									],
 									"path": [
+										"api",
 										"v1",
 										"docGen"
 									]

--- a/frontend/public/files/ches.postman_collection.json
+++ b/frontend/public/files/ches.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4add4d38-2418-4df2-8e81-b68f05069606",
+		"_postman_id": "ab533515-b419-411c-8cd3-b1ff5482f2d5",
 		"name": "Common Hosted Email Service",
 		"description": "CHES - Powered by NodeMailer (a shared library)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -65,8 +65,8 @@
 									}
 								},
 								"url": {
-									"raw": "http://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/email?",
-									"protocol": "http",
+									"raw": "https://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/email",
+									"protocol": "https",
 									"host": [
 										"ches-master-9f0fbe-prod",
 										"pathfinder",
@@ -114,8 +114,8 @@
 									"raw": "{\n    \"attachments\": [\n        {\n            \"content\": \"PGI+SGVsbG8gV29ybGRcITwvYj4=\",\n            \"contentType\": \"string\",\n            \"encoding\": \"base64\",\n            \"filename\": \"testfile.txt\"\n        }\n    ],\n    \"bodyType\": \"text\",\n    \"body\": \"Hello World {{ hello }} content\",\n    \"contexts\": [\n    \t{\n    \t\t\"to\": [\n\t\t        \"email@someemail.com\"\n\t\t    ],\n\t\t    \"context\": {\n\t\t    \t\"orange\": {\n\t\t            \"target\": \"jujaga\"\n\t\t        },\n\t\t        \"hello\": \"jujaga template\"\n\t\t    },\n\t\t    \"delayTS\": 1600000000000,\n\t\t    \"tag\": \"tag\"\n    \t},\n    \t{\n    \t\t\"to\": [\n\t\t        \"gkf63839@aklqo.com\"\n\t\t    ],\n\t\t    \"context\": {\n\t\t    \t\"orange\": {\n\t\t            \"target\": \"lucasoneil\"\n\t\t        },\n\t\t        \"hello\": \"lucas template\"\n\t\t    },\n\t\t    \"delayTS\": 1600000000000,\n\t\t    \"tag\": \"tag\"\n    \t}\n    ],\n    \"encoding\": \"utf-8\",\n    \"from\": \"email.here@gov.bc.ca\",\n    \"priority\": \"normal\",\n    \"subject\": \"Test {{ orange.target }}\"\n}"
 								},
 								"url": {
-									"raw": "http://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/emailMerge?",
-									"protocol": "http",
+									"raw": "https://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/emailMerge",
+									"protocol": "https",
 									"host": [
 										"ches-master-9f0fbe-prod",
 										"pathfinder",
@@ -156,8 +156,8 @@
 									"raw": "{\n    \"attachments\": [\n        {\n            \"content\": \"PGI+SGVsbG8gV29ybGRcITwvYj4=\",\n            \"contentType\": \"string\",\n            \"encoding\": \"base64\",\n            \"filename\": \"testfile.txt\"\n        }\n    ],\n    \"bodyType\": \"text\",\n    \"body\": \"Hello World {{ hello }} content\",\n    \"contexts\": [\n    \t{\n    \t\t\"to\": [\n\t\t        \"email@someemail.com\"\n\t\t    ],\n\t\t    \"context\": {\n\t\t    \t\"orange\": {\n\t\t            \"target\": \"jujaga\"\n\t\t        },\n\t\t        \"hello\": \"jujaga template\"\n\t\t    }\n    \t},\n    \t{\n    \t\t\"to\": [\n\t\t        \"gkf63839@aklqo.com\"\n\t\t    ],\n\t\t    \"context\": {\n\t\t    \t\"orange\": {\n\t\t            \"target\": \"lucasoneil\"\n\t\t        },\n\t\t        \"hello\": \"lucas template\"\n\t\t    },\n\t\t    \"delayTS\": 1579965760073,\n\t\t    \"tag\": \"tag\"\n    \t}\n    ],\n    \"encoding\": \"utf-8\",\n    \"from\": \"some.email@gov.bc.ca\",\n    \"priority\": \"normal\",\n    \"subject\": \"Test {{ orange.target }}\"\n}"
 								},
 								"url": {
-									"raw": "http://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/emailMerge/preview",
-									"protocol": "http",
+									"raw": "https://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/emailMerge/preview",
+									"protocol": "https",
 									"host": [
 										"ches-master-9f0fbe-prod",
 										"pathfinder",
@@ -188,8 +188,8 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/status?txId=f80620bc-08ce-44c1-a89e-552a79cee193",
-									"protocol": "http",
+									"raw": "https://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/status?msgId=58550335-b0f8-417f-aaca-a79fcb407353",
+									"protocol": "https",
 									"host": [
 										"ches-master-9f0fbe-prod",
 										"pathfinder",
@@ -219,8 +219,8 @@
 											"disabled": true
 										},
 										{
-											"key": "txId",
-											"value": "f80620bc-08ce-44c1-a89e-552a79cee193"
+											"key": "msgId",
+											"value": "58550335-b0f8-417f-aaca-a79fcb407353"
 										}
 									]
 								}
@@ -251,7 +251,7 @@
 									"variable": [
 										{
 											"key": "msgId",
-											"value": "571dcf9d-42c1-49bb-b84e-f07175fb0c46"
+											"value": "58550335-b0f8-417f-aaca-a79fcb407353"
 										}
 									]
 								}
@@ -264,8 +264,8 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "http://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/cancel?txId=679e02e8-66ca-4859-8dfb-d8eed3c8d16a",
-									"protocol": "http",
+									"raw": "https://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/cancel?txId=679e02e8-66ca-4859-8dfb-d8eed3c8d16a",
+									"protocol": "https",
 									"host": [
 										"ches-master-9f0fbe-prod",
 										"pathfinder",
@@ -309,8 +309,8 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "http://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/cancel/:msgId",
-									"protocol": "http",
+									"raw": "https://ches-master-9f0fbe-prod.pathfinder.gov.bc.ca/api/v1/cancel/:msgId",
+									"protocol": "https",
 									"host": [
 										"ches-master-9f0fbe-prod",
 										"pathfinder",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Updated postman collection files in nr-get-token that contain API requests for CDOGS and CHES.
They should now match the API calls shown in each project's API docs.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Updated endpoints and http/s

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Presumably the api calls should/will all be going to the 'prod' environment.(?)
Not sure why request for CDOGS > docGen gives 'Access Denied' response
https://cdogs-master-idcqvl-prod.pathfinder.gov.bc.ca/api/v1/docGen

Also, maybe we should include a link in the readme for each project to the postman collection file in nr-get-token github repo. something like:
```

##Connecting to the API with Postman

We offer a 'Collection' of the API requests for this project that can be imported into the useful Postman API development tool (via the 'import' button in the top menu). 
Collections file: https://github.com/bcgov/nr-get-token/blob/master/frontend/public/files/cdogs.postman_collection.json

Note: requests in a Postman collection can have an authentication token set using 'inherit from parent' feature. The authroization token endpoint can be found by going to the API docs page and clicking on the OpenId Connect URL and then finding the 'token endpoint' value. For example: https://sso.pathfinder.gov.bc.ca/auth/realms/jbd6rnxw/protocol/openid-connect/token
```		


