### PR TITLE
Add a common service for NROS folder access in DMS and secure it

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -362,6 +362,8 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
       openshift.selector('secret', "getok-sc-getoktest-secret").exists() &&
       openshift.selector('secret', "getok-sc-getokprod-secret").exists() &&
       openshift.selector('secret', "getok-sc-keycloakint-secret").exists() &&
+      openshift.selector('secret', "getok-sc-keycloaktest-secret").exists() &&
+      openshift.selector('secret', "getok-sc-keycloakprod-secret").exists() &&
       openshift.selector('secret', "getok-sc-mssc-secret").exists())) {
         echo 'Some ConfigMaps and/or Secrets are missing. Please consult the openshift readme for details.'
         throw e

--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -333,6 +333,8 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
       openshift.selector('secret', "getok-sc-getoktest-secret").exists() &&
       openshift.selector('secret', "getok-sc-getokprod-secret").exists() &&
       openshift.selector('secret', "getok-sc-keycloakint-secret").exists() &&
+      openshift.selector('secret', "getok-sc-keycloaktest-secret").exists() &&
+      openshift.selector('secret', "getok-sc-keycloakprod-secret").exists() &&
       openshift.selector('secret', "getok-sc-mssc-secret").exists())) {
         echo 'Some ConfigMaps and/or Secrets are missing. Please consult the openshift readme for details.'
         throw e

--- a/backend/config/custom-environment-variables.json
+++ b/backend/config/custom-environment-variables.json
@@ -44,6 +44,18 @@
         "username": "SC_KC_INT_USERNAME",
         "password": "SC_KC_INT_PASSWORD",
         "realm": "SC_KC_INT_REALM"
+      },
+      "TEST": {
+        "endpoint": "SC_KC_TEST_ENDPOINT",
+        "username": "SC_KC_TEST_USERNAME",
+        "password": "SC_KC_TEST_PASSWORD",
+        "realm": "SC_KC_TEST_REALM"
+      },
+      "PROD": {
+        "endpoint": "SC_KC_PROD_ENDPOINT",
+        "username": "SC_KC_PROD_USERNAME",
+        "password": "SC_KC_PROD_PASSWORD",
+        "realm": "SC_KC_PROD_REALM"
       }
     }
   }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -666,7 +666,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -6523,8 +6522,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -7549,6 +7547,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      }
     },
     "yargs": {
       "version": "13.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,8 @@
     "passport-openidconnect": "0.0.2",
     "pg": "^7.15.1",
     "sequelize": "^5.21.3",
-    "sequelize-cli": "^5.5.1"
+    "sequelize-cli": "^5.5.1",
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "axios-mock-adapter": "^1.17.0",

--- a/backend/src/components/appConfig.js
+++ b/backend/src/components/appConfig.js
@@ -86,13 +86,34 @@ const appConfig = {
           {
             applicationCode: newAppCfg.applicationAcronym,
             name: `${newAppCfg.applicationAcronym}_ROLE`
-          },
+          }
+        ]
+      }];
+
+      if (configForm.commonServices.includes('cmsg')) {
+        newAppCfg.profiles[0].profileRoles.push(
           {
             applicationCode: 'CMSG',
             name: 'SENDER'
           }
-        ]
-      }];
+        );
+      }
+      if (configForm.commonServices.includes('nros-dms')) {
+        newAppCfg.profiles[0].profileRoles.push(
+          {
+            'applicationCode': 'DMS',
+            'name': 'CONTRIBUTOR'
+          },
+          {
+            'applicationCode': 'DMS',
+            'name': 'STAFF_USER_READ'
+          },
+          {
+            'applicationCode': 'NRS_AS',
+            'name': 'READ_ANY_DMS'
+          }
+        );
+      }
 
       newAppCfg.serviceClients[0].authorizations = [{
         profileName: `${newAppCfg.applicationAcronym}_PROFILE`,

--- a/backend/src/routes/v1.js
+++ b/backend/src/routes/v1.js
@@ -1,6 +1,7 @@
 const router = require('express').Router();
 const path = require('path');
 const passport = require('passport');
+const YAML = require('yamljs');
 
 const webAdeRouter = require('./v1/webAde');
 const checksRouter = require('./v1/checks');
@@ -28,6 +29,11 @@ router.get('/docs', (_req, res) => {
 // OpenAPI YAML Spec
 router.get('/api-spec.yaml', (_req, res) => {
   res.sendFile(path.join(__dirname, '../docs/v1.api-spec.yaml'));
+});
+
+// OpenAPI JSON Spec
+router.get('/api-spec.json', (_req, res) => {
+  res.status(200).json(YAML.load(path.join(__dirname, '../docs/v1.api-spec.yaml')));
 });
 
 // WebADE Application Configurations

--- a/frontend/src/components/ConfigForm.vue
+++ b/frontend/src/components/ConfigForm.vue
@@ -395,13 +395,6 @@ export default {
       appConfigStep: 1,
       step1Valid: false,
       step2Valid: false,
-      commonServices: CommonServiceList.filter(
-        serv => serv.type === CommonServiceTypes.WEBADE
-      ).map(serv => ({
-        text: serv.name,
-        value: serv.abbreviation,
-        disabled: serv.disabled
-      })),
       webadeEnvironments: ['INT', 'TEST', 'PROD'],
       keycloakEnvironments: ['DEV', 'TEST', 'PROD'],
       userAppCfg: this.$store.state.configForm.userAppCfg,
@@ -433,7 +426,12 @@ export default {
     };
   },
   computed: {
-    ...mapGetters('auth', ['acronyms', 'hasAcronyms', 'hasWebadePermission']),
+    ...mapGetters('auth', [
+      'acronyms',
+      'hasAcronyms',
+      'hasWebadePermission',
+      'hasWebadeNrosDmsPermission'
+    ]),
     ...mapGetters('configForm', [
       'appConfigAsString',
       'configFormSubmissionResult',
@@ -459,6 +457,17 @@ export default {
         // If keyclok, return all KC common services
         return this.kcServices;
       }
+    },
+    commonServices: function() {
+      return CommonServiceList.filter(
+        serv =>
+          serv.type === CommonServiceTypes.WEBADE &&
+          (serv.abbreviation != 'nros-dms' || this.hasWebadeNrosDmsPermission)
+      ).map(serv => ({
+        text: serv.name,
+        value: serv.abbreviation,
+        disabled: serv.disabled
+      }));
     },
     kcServices: function() {
       return CommonServiceList.filter(

--- a/frontend/src/store/modules/configForm.js
+++ b/frontend/src/store/modules/configForm.js
@@ -101,7 +101,7 @@ export default {
 
           newAppCfg.profiles = [{
             name: `${newAppCfg.applicationAcronym}_PROFILE`,
-            description: `Can send an email with the ${newAppCfg.applicationAcronym} app`,
+            description: `Common service access profile for ${newAppCfg.applicationAcronym} app`,
             secureByOrganization: false,
             availibleTo: [
               'SCL'
@@ -112,13 +112,34 @@ export default {
               {
                 applicationCode: newAppCfg.applicationAcronym,
                 name: `${newAppCfg.applicationAcronym}_ROLE`
-              },
+              }
+            ]
+          }];
+
+          if (state.userAppCfg.commonServices.includes('cmsg')) {
+            newAppCfg.profiles[0].profileRoles.push(
               {
                 applicationCode: 'CMSG',
                 name: 'SENDER'
               }
-            ]
-          }];
+            )
+          }
+          if (state.userAppCfg.commonServices.includes('nros-dms')) {
+            newAppCfg.profiles[0].profileRoles.push(
+              {
+                "applicationCode": "DMS",
+                "name": "CONTRIBUTOR"
+              },
+              {
+                "applicationCode": "DMS",
+                "name": "STAFF_USER_READ"
+              },
+              {
+                "applicationCode": "NRS_AS",
+                "name": "READ_ANY_DMS"
+              }
+            )
+          }
 
           newAppCfg.serviceClients[0].authorizations = [{
             profileName: `${newAppCfg.applicationAcronym}_PROFILE`,

--- a/frontend/src/store/modules/configForm.js
+++ b/frontend/src/store/modules/configForm.js
@@ -122,23 +122,23 @@ export default {
                 applicationCode: 'CMSG',
                 name: 'SENDER'
               }
-            )
+            );
           }
           if (state.userAppCfg.commonServices.includes('nros-dms')) {
             newAppCfg.profiles[0].profileRoles.push(
               {
-                "applicationCode": "DMS",
-                "name": "CONTRIBUTOR"
+                'applicationCode': 'DMS',
+                'name': 'CONTRIBUTOR'
               },
               {
-                "applicationCode": "DMS",
-                "name": "STAFF_USER_READ"
+                'applicationCode': 'DMS',
+                'name': 'STAFF_USER_READ'
               },
               {
-                "applicationCode": "NRS_AS",
-                "name": "READ_ANY_DMS"
+                'applicationCode': 'NRS_AS',
+                'name': 'READ_ANY_DMS'
               }
-            )
+            );
           }
 
           newAppCfg.serviceClients[0].authorizations = [{

--- a/frontend/src/utils/commonServices.js
+++ b/frontend/src/utils/commonServices.js
@@ -22,6 +22,14 @@ export const CommonServiceList = Object.freeze([{
   disabled: true
 },
 {
+  abbreviation: 'nros-dms',
+  type: webade,
+  shortName: 'nros-dms',
+  name: 'NROS Folder Read-all Access in DMS',
+  apiDocLink: 'https://i1apistore.nrs.gov.bc.ca/store/apis/info?name=dms-api&version=v1&provider=admin',
+  disabled: false
+},
+{
   abbreviation: 'dgen',
   type: webade,
   shortName: 'dgen-api',

--- a/frontend/tests/unit/store/fixtures/webAdeConfigs/configBlank.json
+++ b/frontend/tests/unit/store/fixtures/webAdeConfigs/configBlank.json
@@ -1,0 +1,22 @@
+{
+  "@type": "http://webade.gov.bc.ca/applicationConfiguration",
+  "applicationAcronym": "",
+  "custodianNumber": 0,
+  "applicationName": "",
+  "applicationDescription": "",
+  "applicationObjectPrefix": null,
+  "enabledInd": true,
+  "distributeTypeCd": null,
+  "managementEnabledInd": false,
+  "applicationVersion": null,
+  "reportedWebadeVersion": null,
+  "actions": [],
+  "roles": [],
+  "wdePreferences": [],
+  "applicationPreferences": [],
+  "globalPreferences": [],
+  "defaultUserPreferences": [],
+  "profiles": [],
+  "serviceClients": [],
+  "groupAuthorizations": []
+}

--- a/frontend/tests/unit/store/fixtures/webAdeConfigs/configWithCmsg.json
+++ b/frontend/tests/unit/store/fixtures/webAdeConfigs/configWithCmsg.json
@@ -1,0 +1,77 @@
+{
+  "@type": "http://webade.gov.bc.ca/applicationConfiguration",
+  "applicationAcronym": "WORG",
+  "custodianNumber": 0,
+  "applicationName": "Document Generation",
+  "applicationDescription": "A sample application description test",
+  "applicationObjectPrefix": null,
+  "enabledInd": true,
+  "distributeTypeCd": null,
+  "managementEnabledInd": false,
+  "applicationVersion": null,
+  "reportedWebadeVersion": null,
+  "actions": [
+    {
+      "name": "WORG_ACTION",
+      "description": "WORG action",
+      "privilegedInd": false
+    }
+  ],
+  "roles": [
+    {
+      "name": "WORG_ROLE",
+      "description": "WORG Role",
+      "actionNames": [
+        "WORG_ACTION"
+      ]
+    }
+  ],
+  "wdePreferences": [],
+  "applicationPreferences": [],
+  "globalPreferences": [],
+  "defaultUserPreferences": [],
+  "profiles": [
+    {
+      "name": "WORG_PROFILE",
+      "description": "Common service access profile for WORG app",
+      "secureByOrganization": false,
+      "availibleTo": [
+        "SCL"
+      ],
+      "effectiveDate": 1506582000000,
+      "expiryDate": 253402243200000,
+      "profileRoles": [
+        {
+          "applicationCode": "WORG",
+          "name": "WORG_ROLE"
+        },
+        {
+          "applicationCode": "CMSG",
+          "name": "SENDER"
+        }
+      ]
+    }
+  ],
+  "serviceClients": [
+    {
+      "accountName": "WORG_SERVICE_CLIENT",
+      "secret": "••••••••",
+      "oauthScopes": [],
+      "oauthGrantTypes": [],
+      "oauthRedirectUrls": [],
+      "oauthAccessTokenValidity": null,
+      "oauthRefreshTokenValidity": null,
+      "oauthAdditionalInformation": "{\"autoapprove\":\"true\"}",
+      "authorizations": [
+        {
+          "profileName": "WORG_PROFILE",
+          "profileDescription": "Test profile description",
+          "effectiveDate": 1506629523000,
+          "expiryDate": 253402243200000,
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "groupAuthorizations": []
+}

--- a/frontend/tests/unit/store/fixtures/webAdeConfigs/configWithNoServices.json
+++ b/frontend/tests/unit/store/fixtures/webAdeConfigs/configWithNoServices.json
@@ -1,0 +1,34 @@
+{
+  "@type": "http://webade.gov.bc.ca/applicationConfiguration",
+  "applicationAcronym": "WORG",
+  "custodianNumber": 0,
+  "applicationName": "Document Generation",
+  "applicationDescription": "A sample application description test",
+  "applicationObjectPrefix": null,
+  "enabledInd": true,
+  "distributeTypeCd": null,
+  "managementEnabledInd": false,
+  "applicationVersion": null,
+  "reportedWebadeVersion": null,
+  "actions": [],
+  "roles": [],
+  "wdePreferences": [],
+  "applicationPreferences": [],
+  "globalPreferences": [],
+  "defaultUserPreferences": [],
+  "profiles": [],
+  "serviceClients": [
+    {
+      "accountName": "WORG_SERVICE_CLIENT",
+      "secret": "••••••••",
+      "oauthScopes": [],
+      "oauthGrantTypes": [],
+      "oauthRedirectUrls": [],
+      "oauthAccessTokenValidity": null,
+      "oauthRefreshTokenValidity": null,
+      "oauthAdditionalInformation": "{\"autoapprove\":\"true\"}",
+      "authorizations": []
+    }
+  ],
+  "groupAuthorizations": []
+}

--- a/frontend/tests/unit/store/fixtures/webAdeConfigs/configWithNrosDMS.json
+++ b/frontend/tests/unit/store/fixtures/webAdeConfigs/configWithNrosDMS.json
@@ -1,0 +1,85 @@
+{
+  "@type": "http://webade.gov.bc.ca/applicationConfiguration",
+  "applicationAcronym": "MDS",
+  "custodianNumber": 0,
+  "applicationName": "Mines Digital Services",
+  "applicationDescription": "The technologies that support mine oversight",
+  "applicationObjectPrefix": null,
+  "enabledInd": true,
+  "distributeTypeCd": null,
+  "managementEnabledInd": false,
+  "applicationVersion": null,
+  "reportedWebadeVersion": null,
+  "actions": [
+    {
+      "name": "MDS_ACTION",
+      "description": "MDS action",
+      "privilegedInd": false
+    }
+  ],
+  "roles": [
+    {
+      "name": "MDS_ROLE",
+      "description": "MDS Role",
+      "actionNames": [
+        "MDS_ACTION"
+      ]
+    }
+  ],
+  "wdePreferences": [],
+  "applicationPreferences": [],
+  "globalPreferences": [],
+  "defaultUserPreferences": [],
+  "profiles": [
+    {
+      "name": "MDS_PROFILE",
+      "description": "Common service access profile for MDS app",
+      "secureByOrganization": false,
+      "availibleTo": [
+        "SCL"
+      ],
+      "effectiveDate": 1506582000000,
+      "expiryDate": 253402243200000,
+      "profileRoles": [
+        {
+          "applicationCode": "MDS",
+          "name": "MDS_ROLE"
+        },
+        {
+          "applicationCode": "DMS",
+          "name": "CONTRIBUTOR"
+        },
+        {
+          "applicationCode": "DMS",
+          "name": "STAFF_USER_READ"
+        },
+        {
+          "applicationCode": "NRS_AS",
+          "name": "READ_ANY_DMS"
+        }
+      ]
+    }
+  ],
+  "serviceClients": [
+    {
+      "accountName": "MDS_SERVICE_CLIENT",
+      "secret": "••••••••",
+      "oauthScopes": [],
+      "oauthGrantTypes": [],
+      "oauthRedirectUrls": [],
+      "oauthAccessTokenValidity": null,
+      "oauthRefreshTokenValidity": null,
+      "oauthAdditionalInformation": "{\"autoapprove\":\"true\"}",
+      "authorizations": [
+        {
+          "profileName": "MDS_PROFILE",
+          "profileDescription": "Test profile description",
+          "effectiveDate": 1506629523000,
+          "expiryDate": 253402243200000,
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "groupAuthorizations": []
+}

--- a/frontend/tests/unit/store/modules/configForm.spec.js
+++ b/frontend/tests/unit/store/modules/configForm.spec.js
@@ -82,7 +82,21 @@ describe('configForm.js', () => {
   it('updates "existingWebAdeConfig" values when "setExistingWebAdeConfig" is commited', () => {
     expect(store.state.existingWebAdeConfig).toBe('');
     store.commit('setExistingWebAdeConfig', { test: '123' });
-    expect(store.state.existingWebAdeConfig).toBeTruthy();
+    expect(store.getters.existingWebAdeConfig).toBeTruthy();
+  });
+
+  it('updates "userAppCfg" values when "updateUserAppCfg" is commited', () => {
+    store.commit('updateUserAppCfg', { test: 123 });
+    expect(store.state.userAppCfg).toStrictEqual({
+      applicationAcronym: '',
+      applicationName: '',
+      applicationDescription: '',
+      commonServiceType: '',
+      commonServices: [],
+      deploymentMethod: '',
+      clientEnvironment: '',
+      test: 123
+    });
   });
 
   it('returns "false" from "usingWebadeConfig" when "commonServiceType" is KC', () => {

--- a/frontend/tests/unit/store/modules/configForm.spec.js
+++ b/frontend/tests/unit/store/modules/configForm.spec.js
@@ -137,7 +137,7 @@ describe('configForm.js - WebADE configs', () => {
       applicationName: 'Document Generation',
       applicationDescription: 'A sample application description test',
       commonServices: []
-    }
+    };
 
     const config = store.getters.appConfigAsString;
     expect(config).toBeTruthy();
@@ -150,7 +150,7 @@ describe('configForm.js - WebADE configs', () => {
       applicationName: 'Document Generation',
       applicationDescription: 'A sample application description test',
       commonServices: ['cmsg']
-    }
+    };
 
     const config = store.getters.appConfigAsString;
     expect(config).toBeTruthy();
@@ -163,7 +163,7 @@ describe('configForm.js - WebADE configs', () => {
       applicationName: 'Mines Digital Services',
       applicationDescription: 'The technologies that support mine oversight',
       commonServices: ['nros-dms']
-    }
+    };
 
     const config = store.getters.appConfigAsString;
     expect(config).toBeTruthy();
@@ -176,7 +176,7 @@ describe('configForm.js - WebADE configs', () => {
       applicationName: 'Document Generation',
       applicationDescription: 'A sample application description test',
       deploymentMethod: 'deploymentManual'
-    }
+    };
 
     const configWithNoServicesCopy = JSON.parse(JSON.stringify(configWithNoServices));
     configWithNoServicesCopy.serviceClients[0].secret = '${WORG_SERVICE_CLIENT.password}';

--- a/frontend/tests/unit/store/modules/configForm.spec.js
+++ b/frontend/tests/unit/store/modules/configForm.spec.js
@@ -1,7 +1,9 @@
+
+import { cloneDeep } from 'lodash';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
+
 import configFormStore from '@/store/modules/configForm';
-import { cloneDeep } from 'lodash';
 
 describe('configForm.js', () => {
   let store;
@@ -77,6 +79,12 @@ describe('configForm.js', () => {
     expect(store.getters.commonServiceType).toBe('keycloak');
   });
 
+  it('updates "existingWebAdeConfig" values when "setExistingWebAdeConfig" is commited', () => {
+    expect(store.state.existingWebAdeConfig).toBe('');
+    store.commit('setExistingWebAdeConfig', { test: '123' });
+    expect(store.state.existingWebAdeConfig).toBeTruthy();
+  });
+
   it('returns "false" from "usingWebadeConfig" when "commonServiceType" is KC', () => {
     store.commit('setCommonServiceType', 'keycloak');
     expect(store.getters.usingWebadeConfig).toBe(false);
@@ -85,6 +93,83 @@ describe('configForm.js', () => {
   it('returns "true" from "usingWebadeConfig" when "commonServiceType" is WEBADE', () => {
     store.commit('setCommonServiceType', 'webade');
     expect(store.getters.usingWebadeConfig).toBe(true);
+  });
+});
+
+describe('configForm.js - WebADE configs', () => {
+  let store;
+
+  const configBlank = require('../fixtures/webAdeConfigs/configBlank.json');
+  const configWithCmsg = require('../fixtures/webAdeConfigs/configWithCmsg.json');
+  const configWithNoServices = require('../fixtures/webAdeConfigs/configWithNoServices.json');
+  const configWithNrosDMS = require('../fixtures/webAdeConfigs/configWithNrosDMS.json');
+
+  beforeEach(() => {
+    const localVue = createLocalVue();
+    localVue.use(Vuex);
+
+    store = new Vuex.Store(cloneDeep(configFormStore));
+  });
+
+  it('returns the expected WebADE App config based on the user entered details - totally blank', () => {
+    const config = store.getters.appConfigAsString;
+    expect(config).toBeTruthy();
+    expect(config).toEqual(JSON.stringify(configBlank, null, 2));
+  });
+
+  it('returns the expected WebADE App config based on the user entered details - no services', () => {
+    store.state.userAppCfg = {
+      applicationAcronym: 'WORG',
+      applicationName: 'Document Generation',
+      applicationDescription: 'A sample application description test',
+      commonServices: []
+    }
+
+    const config = store.getters.appConfigAsString;
+    expect(config).toBeTruthy();
+    expect(config).toEqual(JSON.stringify(configWithNoServices, null, 2));
+  });
+
+  it('returns the expected WebADE App config based on the user entered details - cmsg', () => {
+    store.state.userAppCfg = {
+      applicationAcronym: 'WORG',
+      applicationName: 'Document Generation',
+      applicationDescription: 'A sample application description test',
+      commonServices: ['cmsg']
+    }
+
+    const config = store.getters.appConfigAsString;
+    expect(config).toBeTruthy();
+    expect(config).toEqual(JSON.stringify(configWithCmsg, null, 2));
+  });
+
+  it('returns the expected WebADE App config based on the user entered details - nros-dms', () => {
+    store.state.userAppCfg = {
+      applicationAcronym: 'MDS',
+      applicationName: 'Mines Digital Services',
+      applicationDescription: 'The technologies that support mine oversight',
+      commonServices: ['nros-dms']
+    }
+
+    const config = store.getters.appConfigAsString;
+    expect(config).toBeTruthy();
+    expect(config).toEqual(JSON.stringify(configWithNrosDMS, null, 2));
+  });
+
+  it('returns the expected WebADE App config with a placeholder secret for the manual deployment mode', () => {
+    store.state.userAppCfg = {
+      applicationAcronym: 'WORG',
+      applicationName: 'Document Generation',
+      applicationDescription: 'A sample application description test',
+      deploymentMethod: 'deploymentManual'
+    }
+
+    const configWithNoServicesCopy = JSON.parse(JSON.stringify(configWithNoServices));
+    configWithNoServicesCopy.serviceClients[0].secret = '${WORG_SERVICE_CLIENT.password}';
+
+    const config = store.getters.appConfigAsString;
+    expect(config).toBeTruthy();
+    expect(config).toEqual(JSON.stringify(configWithNoServicesCopy, null, 2));
   });
 
 });

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -85,6 +85,19 @@ oc create -n k8vopl-<env> secret generic getok-sc-keycloakint-secret \
   --from-literal=password=<password>
 ```
 
+```sh
+oc create -n k8vopl-<env> secret generic getok-sc-keycloaktest-secret \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=<username> \
+  --from-literal=password=<password>
+```
+
+```sh
+oc create -n k8vopl-<env> secret generic getok-sc-keycloakprod-secret \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=<username> \
+  --from-literal=password=<password>
+```
 
 ## Build Config & Deployment
 

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -33,7 +33,11 @@ oc create -n k8vopl-<env> configmap getok-sc-config \
   --from-literal=SC_GETOK_ENDPOINT_PROD=https://api.nrs.gov.bc.ca/webade-api/v1 \
   --from-literal=SC_MSSC_ENDPOINT=https://i1api.nrs.gov.bc.ca/cmsg-messaging-api/v1 \
   --from-literal=SC_KC_INT_ENDPOINT=https://sso-dev.pathfinder.gov.bc.ca \
-  --from-literal=SC_KC_INT_REALM=jbd6rnxw
+  --from-literal=SC_KC_TEST_ENDPOINT=https://sso-test.pathfinder.gov.bc.ca \
+  --from-literal=SC_KC_PROD_ENDPOINT=https://sso.pathfinder.gov.bc.ca \
+  --from-literal=SC_KC_INT_REALM=jbd6rnxw\
+  --from-literal=SC_KC_TEST_REALM=jbd6rnxw\
+  --from-literal=SC_KC_PROD_REALM=jbd6rnxw
 ```
 
 ### Secrets

--- a/openshift/backend.dc.yaml
+++ b/openshift/backend.dc.yaml
@@ -203,6 +203,26 @@ objects:
               secretKeyRef:
                 key: password
                 name: getok-sc-keycloakint-secret
+          - name: SC_KC_TEST_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: username
+                name: getok-sc-keycloaktest-secret
+          - name: SC_KC_TEST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: getok-sc-keycloaktest-secret
+          - name: SC_KC_PROD_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: username
+                name: getok-sc-keycloakprod-secret
+          - name: SC_KC_PROD_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: getok-sc-keycloakprod-secret
           envFrom:
           - configMapRef:
               name: getok-oidc-config


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-438

Add a new option, only available to specific people and acronyms, to the WebADE common service dropdown.

Also adding a json representation of the docs, as we're doing for all apis.

Also add missing keycloak config.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
 New feature (non-breaking change which adds functionality) 
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This is secured at the GETOK API level as well, so attempting to POST an app config to accomplish adding this webade access will return a 403 unless the permissions are there.

The acronym in the GETOK database must have a flag set to allow this.

The user must have a role WEBADE_PERMISSION_NROS_DMS as well.