### PR TITLE
added dialog component for new app form error/success messages

### DIFF
--- a/frontend/src/assets/scss/style.scss
+++ b/frontend/src/assets/scss/style.scss
@@ -1,0 +1,15 @@
+.BC-Gov-PrimaryButton.v-btn {
+    background-color: #003366;
+    border: none;
+    border-radius: 4px;
+    color: white;
+    padding: 12px 32px !important;
+    text-align: center;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.BC-Gov-PrimaryButton:hover, .v-btn:hover {
+  text-decoration: underline;
+  opacity: 0.80;
+}

--- a/frontend/src/assets/scss/style.scss
+++ b/frontend/src/assets/scss/style.scss
@@ -1,15 +1,22 @@
+
 .BC-Gov-PrimaryButton.v-btn {
-    background-color: #003366;
-    border: none;
-    border-radius: 4px;
-    color: white;
-    padding: 12px 32px !important;
-    text-align: center;
-    text-decoration: none;
-    cursor: pointer;
+  background-color: #003366;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  padding: 12px 32px !important;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
 }
 
 .BC-Gov-PrimaryButton:hover, .v-btn:hover {
-  text-decoration: underline;
-  opacity: 0.80;
+text-decoration: underline;
+opacity: 0.80;
+}
+
+.BC-Gov-PrimaryButton.light.v-btn {
+  background-color: #fff;
+  border: 2px solid #003366;
+  color: #003366;
 }

--- a/frontend/src/components/Dialog.vue
+++ b/frontend/src/components/Dialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-if="showDialog" v-model="showDialog" width="500">
+  <v-dialog v-if="show" v-model="show" width="500">
     <v-card>
       <div class="dialog-body">
         <v-card-title class primary-title>
@@ -17,7 +17,7 @@
         </v-card-text>
       </div>
       <v-card-actions class="justify-center">
-        <v-btn class="BC-Gov-PrimaryButton mb-5" text @click="showDialog = false">
+        <v-btn class="BC-Gov-PrimaryButton mb-5" text @click="closeDialog">
           <slot name="button-text">OK</slot>
         </v-btn>
       </v-card-actions>
@@ -28,11 +28,13 @@
 <script>
 export default {
   name: 'Dialog',
-  props: ['show'],
-  data: function() {
-    return {
-      showDialog: this.show
-    };
+  props: {
+    'show': Boolean
+  },
+  methods: {
+    closeDialog (){
+      this.$emit('close-dialog');
+    }
   }
 };
 </script>

--- a/frontend/src/components/Dialog.vue
+++ b/frontend/src/components/Dialog.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-dialog v-if="showDialog" v-model="showDialog" width="500">
+    <v-card>
+      <div class="dialog-body">
+        <v-card-title class primary-title>
+          <slot name="title"></slot>
+        </v-card-title>
+        <v-card-text>
+          <div class="dialog-icon">
+            <slot name="icon">
+              <v-icon medium>default-icon</v-icon>
+            </slot>
+          </div>
+          <div class="dialog-text">
+            <slot name="text">default text</slot>
+          </div>
+        </v-card-text>
+      </div>
+      <v-card-actions class="justify-center">
+        <v-btn class="BC-Gov-PrimaryButton mb-5" text @click="showDialog = false">
+          <slot name="button-text">OK</slot>
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  name: 'Dialog',
+  props: ['show'],
+  data: function() {
+    return {
+      showDialog: this.show
+    };
+  }
+};
+</script>
+
+<style scoped>
+.v-card__text {
+  display: flex !important;
+  padding: 20px;
+}
+.dialog-icon {
+  margin-right: 10px;
+  object-fit: contain;
+  align-self: flex-start;
+}
+.dialog-text {
+  flex: 1 1 auto;
+}
+</style>

--- a/frontend/src/components/Dialog.vue
+++ b/frontend/src/components/Dialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-if="show" v-model="show" width="500">
+  <v-dialog v-model="show" width="500">
     <v-card>
       <div class="dialog-body">
         <v-card-title class primary-title>

--- a/frontend/src/components/RegistrationForm.vue
+++ b/frontend/src/components/RegistrationForm.vue
@@ -7,21 +7,11 @@
           <v-icon class="mr-2">email</v-icon>Register a New Application
         </v-card-title>
         <v-card-text>
-          <v-alert :value="errorOccurred" tile type="error" transition="scale-transition">
-            An error occurred while attempting to Register your application.
-            <br />You can also register your application by sending an email to
-            <a
-              class="white--text"
-              href="mailto:NR.CommonServiceShowcase@gov.bc.ca?subject=GETOK Registration for <acronym> - <idir>"
-            >NR.CommonServiceShowcase@gov.bc.ca</a><br />
-            Please include your Acronym as well as your IDIR username in your email.
-          </v-alert>
           <p>
-            Please enter an acronym for the application you are registering.<br />
-            Use the optional Comments field to describe your project or indicate relavant branch / ministries.<br />
-            This message is sent to the Common Service Showcase Team to authorize you for that application.
+            Please enter an acronym for the application you are registering.
+            <br />Use the optional Comments field to describe your project or indicate relavant branch / ministries.
+            <br />This message is sent to the Common Service Showcase Team to authorize you for that application.
           </p>
-
           <v-form ref="form" v-model="valid" lazy-validation>
             <p class="mb-0">
               My Email:
@@ -71,6 +61,34 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <!-- error dialog -->
+     <Dialog v-bind:show="errorOccurred">
+      <template v-slot:icon>
+        <v-icon large color="red">cancel</v-icon>
+      </template>
+      <template v-slot:text>
+        <p>
+          An error occurred while attempting to add your application.
+          <br />You can also add your application by sending an email to
+          <a
+            href="mailto:NR.CommonServiceShowcase@gov.bc.ca?subject=GETOK Registration for <acronym> - <idir>"
+          >NR.CommonServiceShowcase@gov.bc.ca</a>
+        </p>
+        <p>Please include your Acronym as well as your IDIR username in your email.</p>
+      </template>
+    </Dialog>
+
+    <!-- success dialog -->
+    <Dialog v-bind:show="registerSuccess">
+      <template v-slot:icon>
+        <v-icon large color="green">check_circle_outline</v-icon>
+      </template>
+      <template v-slot:text>
+        <p>Your Registration was sent successfully. You will be sent an email to ${this.userInfo.emailAddress} when your application has been authorized.</p>
+      </template>
+    </Dialog>
+
   </v-btn>
 </template>
 
@@ -79,8 +97,13 @@
 import ApiService from '@/common/apiService';
 import { FieldValidations } from '@/utils/constants.js';
 import { mapGetters } from 'vuex';
+import '@/assets/scss/style.scss';
+import Dialog from './Dialog.vue';
 
 export default {
+  components: {
+    Dialog
+  },
   data: function() {
     return {
       applicationAcronym: '',
@@ -97,6 +120,7 @@ export default {
       errorOccurred: false,
       fieldValidations: FieldValidations,
       registrationDialog: false,
+      registerSuccess: false,
       valid: false
     };
   },
@@ -107,10 +131,11 @@ export default {
     async cancel() {
       this.errorOccurred = false;
       this.registrationDialog = false;
+      this.registerSuccess = false;
     },
     async postRegistrationForm() {
-      this.$store.commit('configForm/clearConfigSubmissionMsgs');
       this.errorOccurred = false;
+      this.registerSuccess = false;
       if (this.$refs.form.validate()) {
         try {
           const response = await ApiService.sendRegistrationEmail({
@@ -121,10 +146,7 @@ export default {
           });
           if (response) {
             this.registrationDialog = false;
-            this.$store.commit(
-              'configForm/setConfigSubmissionSuccess',
-              `Your Registration was sent successfully. You will be sent an email to ${this.userInfo.emailAddress} when your application has been authorized.`
-            );
+            this.registerSuccess = true;
           } else {
             this.errorOccurred = true;
           }

--- a/frontend/src/components/RegistrationForm.vue
+++ b/frontend/src/components/RegistrationForm.vue
@@ -1,69 +1,107 @@
 <template>
   <v-btn class="mr-2" color="success" @click="registrationDialog = true">
-    Register a new app
-    <v-dialog v-model="registrationDialog" persistent max-width="700">
+    Register a new application
+    <v-dialog v-model="registrationDialog" persistent max-width="500">
       <v-card>
-        <v-card-title class="headline">
-          <v-icon class="mr-2">email</v-icon>Register a New Application
+        <v-card-title class="headline underline">
+          <v-icon class="mr-2">email</v-icon>Request Permission
         </v-card-title>
         <v-card-text>
           <p>
-            Please enter an acronym for the application you are registering.
-            <br />Use the optional Comments field to describe your project or indicate relavant branch / ministries.
-            <br />This message is sent to the Common Service Showcase Team to authorize you for that application.
+            Please submit an Acronym for the application you wish to add.
+            <br />You will get an email once permissions have been set up.
           </p>
           <v-form ref="form" v-model="valid" lazy-validation>
-            <p class="mb-0">
-              My Email:
-              <strong>{{userInfo.emailAddress}}</strong>
-              <br />My IDIR:
-              <strong>{{userInfo.idir}}</strong>
-            </p>
             <v-row>
-              <v-col cols="12" sm="6">
+              <v-col>
+                <label>My Email</label>
                 <v-text-field
-                  :counter="fieldValidations.ACRONYM_MAX_LENGTH"
-                  label="Application Acronym"
+                  readonly
+                  :value="userInfo.emailAddress"
+                  hide-details="auto"
+                  solo
+                  dense
+                  single-line
+                  outlined
+                  flat
+                ></v-text-field>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <label>My IDIR</label>
+                <v-text-field
+                  readonly
+                  :value="userInfo.idir"
+                  hide-details="auto"
+                  solo
+                  single-line
+                  dense
+                  outlined
+                  flat
+                ></v-text-field>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <label>Application Acronym &nbsp;</label>
+                <v-tooltip bottom>
+                  <template v-slot:activator="{ on }">
+                    <v-icon v-on="on">help_outline</v-icon>
+                  </template>
+                  The Application Acronym must comply with the following format:
+                  <ul>
+                    <li>UPPERCASE LETTERS ONLY</li>
+                    <li>Underscores may be placed between letters</li>
+                    <li>Must begin and end with a letter</li>
+                    <li>At least {{ fieldValidations.ACRONYM_MIN_LENGTH }} characters</li>
+                    <li>
+                      Examples:
+                      <em>ABCD</em>,
+                      <em>ABCD_WXYZ</em>
+                    </li>
+                  </ul>
+                </v-tooltip>
+                <v-text-field
+                  placeholder="For example: 'ABC_DEF'"
                   required
                   :rules="applicationAcronymRules"
                   v-model="applicationAcronym"
+                  hide-details="auto"
+                  solo
+                  dense
+                  single-line
+                  outlined
+                  flat
                 >
-                  <template v-slot:append-outer>
-                    <v-tooltip bottom>
-                      <template v-slot:activator="{ on }">
-                        <v-icon v-on="on">help_outline</v-icon>
-                      </template>
-                      The Application Acronym must comply with the following format:
-                      <ul>
-                        <li>UPPERCASE LETTERS ONLY</li>
-                        <li>Underscores may be placed between letters</li>
-                        <li>Must begin and end with a letter</li>
-                        <li>At least {{ fieldValidations.ACRONYM_MIN_LENGTH }} characters</li>
-                        <li>
-                          Examples:
-                          <em>ABCD</em>,
-                          <em>ABCD_WXYZ</em>
-                        </li>
-                      </ul>
-                    </v-tooltip>
-                  </template>
+                  <template v-slot:append-outer></template>
                 </v-text-field>
               </v-col>
             </v-row>
-
-            <v-textarea v-model="comments" rows="1" auto-grow label="Comments"></v-textarea>
+            <v-row>
+              <v-col>
+                <label>Comments (optional)</label>
+                <v-textarea
+                  v-model="comments"
+                  rows="3"
+                  auto-grow
+                  hide-details="auto"
+                  dense
+                  solo
+                  outlined
+                  flat
+                ></v-textarea>
+              </v-col>
+            </v-row>
           </v-form>
         </v-card-text>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn text @click="cancel()">Cancel</v-btn>
-          <v-btn color="success darken-1" text @click="postRegistrationForm()">SEND</v-btn>
+        <v-card-actions class="justify-center pb-8">
+          <v-btn class="BC-Gov-PrimaryButton light" text @click="cancel()">Cancel</v-btn>
+          <v-btn class="BC-Gov-PrimaryButton" text @click="postRegistrationForm()">Submit</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
-
-    <!-- error dialog -->
-     <Dialog v-bind:show="errorOccurred">
+    <Dialog v-bind:show="errorOccurred">
       <template v-slot:icon>
         <v-icon large color="red">cancel</v-icon>
       </template>
@@ -78,8 +116,6 @@
         <p>Please include your Acronym as well as your IDIR username in your email.</p>
       </template>
     </Dialog>
-
-    <!-- success dialog -->
     <Dialog v-bind:show="registerSuccess">
       <template v-slot:icon>
         <v-icon large color="green">check_circle_outline</v-icon>
@@ -88,11 +124,8 @@
         <p>Your Registration was sent successfully. You will be sent an email to ${this.userInfo.emailAddress} when your application has been authorized.</p>
       </template>
     </Dialog>
-
   </v-btn>
 </template>
-
-
 <script>
 import ApiService from '@/common/apiService';
 import { FieldValidations } from '@/utils/constants.js';

--- a/frontend/src/components/RegistrationForm.vue
+++ b/frontend/src/components/RegistrationForm.vue
@@ -101,7 +101,8 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
-    <Dialog v-bind:show="errorOccurred">
+
+    <Dialog v-bind:show="errorOccurred" @close-dialog="errorOccurred = false">
       <template v-slot:icon>
         <v-icon large color="red">cancel</v-icon>
       </template>
@@ -116,7 +117,8 @@
         <p>Please include your Acronym as well as your IDIR username in your email.</p>
       </template>
     </Dialog>
-    <Dialog v-bind:show="registerSuccess">
+
+    <Dialog v-bind:show="registerSuccess" @close-dialog="registerSuccess = false">
       <template v-slot:icon>
         <v-icon large color="green">check_circle_outline</v-icon>
       </template>
@@ -174,7 +176,8 @@ export default {
           const response = await ApiService.sendRegistrationEmail({
             applicationAcronym: this.applicationAcronym,
             comments: this.comments,
-            from: this.userInfo.emailAddress,
+            //from: this.userInfo.emailAddress,
+            from: 'abc',
             idir: this.userInfo.idir
           });
           if (response) {

--- a/frontend/src/components/RegistrationForm.vue
+++ b/frontend/src/components/RegistrationForm.vue
@@ -176,8 +176,7 @@ export default {
           const response = await ApiService.sendRegistrationEmail({
             applicationAcronym: this.applicationAcronym,
             comments: this.comments,
-            //from: this.userInfo.emailAddress,
-            from: 'abc',
+            from: this.userInfo.emailAddress,
             idir: this.userInfo.idir
           });
           if (response) {

--- a/frontend/tests/unit/components/RegistrationForm.spec.js
+++ b/frontend/tests/unit/components/RegistrationForm.spec.js
@@ -33,9 +33,9 @@ describe('RegistrationForm.vue', () => {
 
     // prevent 'Unable to locate target [data-app]' warning
     // caused by dialog not having data-app attribute when mounted
-    const el = document.createElement('div')
-    el.setAttribute('data-app', true)
-    document.body.appendChild(el)
+    const el = document.createElement('div');
+    el.setAttribute('data-app', true);
+    document.body.appendChild(el);
 
   });
 

--- a/frontend/tests/unit/components/RegistrationForm.spec.js
+++ b/frontend/tests/unit/components/RegistrationForm.spec.js
@@ -1,0 +1,55 @@
+import Vuetify from 'vuetify';
+import Vuex from 'vuex';
+import { mount, createLocalVue } from '@vue/test-utils';
+import RegistrationForm from '@/components/RegistrationForm';
+import auth from '@/store/modules/auth';
+
+const localVue = createLocalVue();
+
+localVue.use(Vuetify);
+localVue.use(Vuex);
+
+describe('RegistrationForm.vue', () => {
+  let store;
+  let vuetify;
+  let wrapper;
+
+  beforeEach(() => {
+
+    vuetify = new Vuetify();
+
+    store = new Vuex.Store({
+      state: {},
+      modules: {
+        auth
+      }
+    });
+
+    wrapper = mount(RegistrationForm, {
+      localVue,
+      vuetify,
+      store
+    });
+
+    // prevent 'Unable to locate target [data-app]' warning
+    // caused by dialog not having data-app attribute when mounted
+    const el = document.createElement('div')
+    el.setAttribute('data-app', true)
+    document.body.appendChild(el)
+
+  });
+
+
+  it('renders registration form content', () => {
+    wrapper.find('button').trigger('click');
+    expect(wrapper.find('.v-dialog--active').text()).toContain('Request Permission');
+  });
+
+  it('opens registration form modal when button is clicked', () => {
+    wrapper.find('button').trigger('click');
+    expect(wrapper.find('.v-dialog--active').exists()).toBe(true);
+  });
+
+
+
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

relates to: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-633

With new GetOK UX we want new app registration error/success messages implemented with a re-usable 'modal' component.

I've created this new component (named: 'Dialog') but I am having trouble making it reactive to the form submission. If I hard-code 'errorOccurred = true' the component appears.
I've been reading the Vue docs but haven't figured it out yet.

I've also styled the form as requested by Mina. 
see screenshots in: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-721
As GetOK isn't a truely public website and overriding Vuetify styles isnt straight-forward there is some compromise in firm styling. for example input borders

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->
New feature (non-breaking change which adds functionality)
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
