### PR TITLE
Administrative endpoint for registering users

### DIFF
--- a/backend/src/components/acronyms.js
+++ b/backend/src/components/acronyms.js
@@ -22,6 +22,18 @@ const acronyms = {
       log.error('getAcronym', error.message);
       throw new Error(`An error occured fetching acronym details from GETOK database. ${error.message}`);
     }
+  },
+
+  registerUserToAcronym: async (acronym, username) => {
+    await acronymService.findOrCreateList(acronymList);
+
+    // Add user if they don't already exist
+    await userService.findOrCreate(req.user.id, req.user.displayName, req.user._json.preferred_username);
+
+    // Add update user-acronym association from JWT roles
+    await acronymList.forEach(value => {
+      userService.addAcronym(req.user.id, value);
+    });
   }
 };
 

--- a/backend/src/components/acronyms.js
+++ b/backend/src/components/acronyms.js
@@ -26,11 +26,13 @@ const acronyms = {
   },
 
   registerUserToAcronym: async (token, kcRealm, acronym, username) => {
+    acronym = acronym.toUpperCase();
+    username = username.toLowerCase();
     await acronymService.findOrCreateList([acronym]);
 
     // Get user details from KC
     const url = `${kcRealm.replace('realms', 'admin/realms')}/users?username=${username}`;
-    log.debug(url);
+    log.debug('registerUserToAcronym', url);
     const auth = `Bearer ${token}`;
     const response = await axios.get(url, { headers: { Authorization: auth }});
     const users = response.data;

--- a/backend/src/components/auth.js
+++ b/backend/src/components/auth.js
@@ -104,6 +104,16 @@ const auth = {
     }
 
     next();
+  },
+
+  // Populate and update database based on incoming JWT token
+  async updateDBFromToken(req, _res, next) {
+    if (req.user && req.user.jwt) {
+      // Add user if they don't already exist
+      await userService.findOrCreate(req.user.id, req.user.displayName, req.user._json.preferred_username);
+    }
+
+    next();
   }
 };
 

--- a/backend/src/components/auth.js
+++ b/backend/src/components/auth.js
@@ -4,8 +4,7 @@ const jsonwebtoken = require('jsonwebtoken');
 const log = require('npmlog');
 const qs = require('querystring');
 
-const { acronymService, userService } = require('../services');
-const permissionHelpers = require('./permissionHelpers');
+const { userService } = require('../services');
 const utils = require('./utils');
 
 const auth = {
@@ -102,33 +101,6 @@ const auth = {
       }
     } catch (error) {
       log.error('refreshJWT', error.message);
-    }
-
-    next();
-  },
-
-  // Populate and update database based on incoming JWT token
-  async updateDBFromToken(req, _res, next) {
-    if (req.user && req.user.jwt) {
-      const payload = jsonwebtoken.decode(req.user.jwt);
-      const roles = payload.realm_access.roles;
-
-      // Add keycloak authorized acronyms if they don't already exist
-      let acronymList = [];
-      if (typeof roles === 'object' && roles instanceof Array) {
-        acronymList = permissionHelpers.filterAppAcronymRoles(roles);
-      }
-      await acronymService.findOrCreateList(acronymList);
-
-      // Add user if they don't already exist
-      await userService.findOrCreate(req.user.id, req.user.displayName, req.user._json.preferred_username);
-
-      // Add update user-acronym association from JWT roles
-      await acronymList.forEach(value => {
-        userService.addAcronym(req.user.id, value);
-      });
-
-      // TODO: Consider removing user-acronym associations if they are not on JWT
     }
 
     next();

--- a/backend/src/components/keyCloakServiceClientMgr.js
+++ b/backend/src/components/keyCloakServiceClientMgr.js
@@ -154,6 +154,25 @@ class KeyCloakServiceClientManager {
       return undefined;
     }
   }
+
+  async getUser(username) {
+    log.info('KeyCloakServiceClientManager.getUser', username);
+    if (!username) {
+      log.error('KeyCloakServiceClientManager.getUser', 'No user provided.');
+      throw new Error('Cannot get a user in KeyCloak realm: username required.');
+    }
+
+    const users = await this.svc.getUsers(username);
+
+    if (users && users.length) {
+      // Can only be one user by identified username (idir or github or whatever)
+      return users[0];
+    } else {
+      log.debug('KeyCloakServiceClientManager.getUser', `No user found for ${username}`);
+      return undefined;
+
+    }
+  }
 }
 
 module.exports = KeyCloakServiceClientManager;

--- a/backend/src/components/keyCloakServiceClientMgr.js
+++ b/backend/src/components/keyCloakServiceClientMgr.js
@@ -155,10 +155,10 @@ class KeyCloakServiceClientManager {
     }
   }
 
-  async getUser(username) {
-    log.info('KeyCloakServiceClientManager.getUser', username);
+  async findUser(username) {
+    log.info('KeyCloakServiceClientManager.findUser', username);
     if (!username) {
-      log.error('KeyCloakServiceClientManager.getUser', 'No user provided.');
+      log.error('KeyCloakServiceClientManager.findUser', 'No user provided.');
       throw new Error('Cannot get a user in KeyCloak realm: username required.');
     }
 
@@ -168,9 +168,8 @@ class KeyCloakServiceClientManager {
       // Can only be one user by identified username (idir or github or whatever)
       return users[0];
     } else {
-      log.debug('KeyCloakServiceClientManager.getUser', `No user found for ${username}`);
+      log.debug('KeyCloakServiceClientManager.findUser', `No user found for ${username}`);
       return undefined;
-
     }
   }
 }

--- a/backend/src/components/permissionHelpers.js
+++ b/backend/src/components/permissionHelpers.js
@@ -1,4 +1,4 @@
-const log = require('npmlog');
+fconst log = require('npmlog');
 
 const { userService } = require('../services');
 

--- a/backend/src/components/permissionHelpers.js
+++ b/backend/src/components/permissionHelpers.js
@@ -1,12 +1,8 @@
-fconst log = require('npmlog');
+const log = require('npmlog');
 
 const { userService } = require('../services');
 
 const permissionHelpers = {
-  // TODO: this is likely soon to be refactored out, as we will be pulling acronyms from the DB, not from access roles
-  // Returns only app acronym based roles
-  filterAppAcronymRoles: roles => roles.filter(role => !role.match(/offline_access|uma_authorization|WEBADE_CFG_READ|WEBADE_CFG_READ_ALL|WEBADE_PERMISSION|WEBADE_PERMISSION_NROS_DMS/)),
-
   /**
    *  @function checkAcronymPermission
    *  Is this call allowed to be made for the acronym it's being made for?

--- a/backend/src/components/realmAdminSvc.js
+++ b/backend/src/components/realmAdminSvc.js
@@ -388,6 +388,24 @@ class RealmAdminService {
     //204 created...
     return response;
   }
+
+  // Get from the users list with the username query param. If we want to be able to filter by more can refactor this method
+  // to take in search parameters. https://www.keycloak.org/docs-api/5.0/rest-api/index.html#_users_resource
+  async getUsers(username) {
+    if (!username) {
+      log.error('RealmAdminService.getUsers', 'username parameter is null.');
+      throw new Error('Cannot get users: username parameter cannot be null.');
+    }
+
+    const url = `${this.realmAdminUrl}/users?username=${username}`;
+    log.error(url);
+    const response = await this.axios.get(url)
+      .catch(e => {
+        log.error('RealmAdminService.getUsers', JSON.stringify(e));
+        throw e;
+      });
+    return response.data;
+  }
 }
 
 module.exports = RealmAdminService;

--- a/backend/src/components/realmAdminSvc.js
+++ b/backend/src/components/realmAdminSvc.js
@@ -350,7 +350,6 @@ class RealmAdminService {
     }
 
     const url = `${this.realmAdminUrl}/clients/${clientId}/roles/${roleName}/composites`;
-    log.error(url);
     const response = await this.axios.get(url)
       .catch(e => {
         log.error('RealmAdminService.getRoleComposites', JSON.stringify(e));
@@ -398,7 +397,6 @@ class RealmAdminService {
     }
 
     const url = `${this.realmAdminUrl}/users?username=${username}`;
-    log.error(url);
     const response = await this.axios.get(url)
       .catch(e => {
         log.error('RealmAdminService.getUsers', JSON.stringify(e));

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -54,7 +54,7 @@ router.post('/refresh', [
   return res.status(200).json(refresh);
 });
 
-router.use('/token', auth.refreshJWT, auth.updateDBFromToken, auth.getUserAcronyms, (req, res) => {
+router.use('/token', auth.refreshJWT, auth.getUserAcronyms, (req, res) => {
   if (req.user && req.user.jwt && req.user.refreshToken) {
     res.status(200).json(req.user);
   } else {

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -54,7 +54,7 @@ router.post('/refresh', [
   return res.status(200).json(refresh);
 });
 
-router.use('/token', auth.refreshJWT, auth.getUserAcronyms, (req, res) => {
+router.use('/token', auth.refreshJWT, auth.updateDBFromToken, auth.getUserAcronyms, (req, res) => {
   if (req.user && req.user.jwt && req.user.refreshToken) {
     res.status(200).json(req.user);
   } else {

--- a/backend/src/routes/v1/acronyms.js
+++ b/backend/src/routes/v1/acronyms.js
@@ -42,8 +42,16 @@ acronyms.get('/:appAcronym/addUser/:username', [
     });
   }
 
+  if (!req.params.appAcronym || !req.params.username) {
+    res.status(400).json({
+      message: 'Must supply app acronym and user (ex: myname@idir)'
+    });
+    return res;
+  }
+
   try {
-    const response = await acronymComponent.registerUserToAcronym(req.params.appAcronym, req.params.username);
+    const token = req.headers.authorization.split(' ')[1];
+    const response = await acronymComponent.registerUserToAcronym(token, req.user.jwt.iss, req.params.appAcronym.toUpperCase(), req.params.username.toLowerCase());
     if (response) {
       return res.status(200).json(response);
     } else {

--- a/backend/src/routes/v1/acronyms.js
+++ b/backend/src/routes/v1/acronyms.js
@@ -51,7 +51,7 @@ acronyms.get('/:appAcronym/addUser/:username', [
 
   try {
     const token = req.headers.authorization.split(' ')[1];
-    const response = await acronymComponent.registerUserToAcronym(token, req.user.jwt.iss, req.params.appAcronym.toUpperCase(), req.params.username.toLowerCase());
+    const response = await acronymComponent.registerUserToAcronym(token, req.user.jwt.iss, req.params.appAcronym, req.params.username);
     if (response) {
       return res.status(200).json(response);
     } else {

--- a/backend/src/routes/v1/acronyms.js
+++ b/backend/src/routes/v1/acronyms.js
@@ -31,4 +31,31 @@ acronyms.get('/:appAcronym', [
   }
 });
 
+// A special administrative call to add users to acronym. This is a temporary shim until we have an actual administrative
+// section of the app in place
+acronyms.get('/:appAcronym/addUser/:username', [
+], async (req, res) => {
+  // Check for required permissions
+  if (!req.user.jwt.realm_access.roles.includes('GETOK_ADMIN_ADD_USER')) {
+    return res.status(403).json({
+      message: 'Access Denied'
+    });
+  }
+
+  try {
+    const response = await acronymComponent.registerUserToAcronym(req.params.appAcronym, req.params.username);
+    if (response) {
+      return res.status(200).json(response);
+    } else {
+      return res.status(404).end();
+    }
+  } catch (error) {
+    log.error(error);
+    res.status(500).json({
+      message: error.message
+    });
+    return res;
+  }
+});
+
 module.exports = acronyms;

--- a/backend/tests/unit/components/auth.spec.js
+++ b/backend/tests/unit/components/auth.spec.js
@@ -4,16 +4,11 @@ const log = require('npmlog');
 const MockAdapter = require('axios-mock-adapter');
 
 const auth = require('../../../src/components/auth');
-const {
-  acronymService,
-  userService
-} = require('../../../src/services');
 const utils = require('../../../src/components/utils');
 
 log.level = config.get('server.logLevel');
 const mockAxios = new MockAdapter(axios);
 
-const userId = '00000000-0000-0000-0000-000000000000';
 const expiredToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjF9.2H0EJnt58ApysedXcvNUAy6FhgBIbDmPfq9d79qF4yQ';
 const endlessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjB9.JWKPB-5Q8rTYzl-MfhRGpP9WpDpQxC7JkIAGFMDZnpg';
 const validToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjk5OTk5OTk5OTksInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJNU1NDIiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiIsIkRPTU8iXX19.4YqQAETI2DnYVsQ7a4R998z5OUyRVcUQIAV7GY3LwG0';
@@ -108,7 +103,7 @@ describe('refreshJWT', () => {
   });
 
   it('should not have a user if no user or jwt exists', async () => {
-    const result = await auth.refreshJWT({}, null, () => {});
+    const result = await auth.refreshJWT({}, null, () => { });
     expect(result).toBeUndefined();
   });
 
@@ -118,7 +113,7 @@ describe('refreshJWT', () => {
         jwt: validToken,
         refreshToken: endlessToken
       }
-    }, null, () => {});
+    }, null, () => { });
     expect(result).toBeUndefined();
   });
 
@@ -128,7 +123,7 @@ describe('refreshJWT', () => {
         jwt: expiredToken,
         refreshToken: expiredToken
       }
-    }, null, () => {});
+    }, null, () => { });
     expect(result).toBeUndefined();
   });
 
@@ -143,7 +138,7 @@ describe('refreshJWT', () => {
         jwt: expiredToken,
         refreshToken: endlessToken
       }
-    }, null, () => {});
+    }, null, () => { });
     expect(result).toBeUndefined();
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(endlessToken);
@@ -160,46 +155,9 @@ describe('refreshJWT', () => {
         jwt: expiredToken,
         refreshToken: endlessToken
       }
-    }, null, () => {});
+    }, null, () => { });
     expect(result).toBeUndefined();
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(endlessToken);
-  });
-});
-
-describe('updateDBFromToken', () => {
-  it('should be a pass-through if there is no user', async () => {
-    const result = await auth.updateDBFromToken({}, null, () => {});
-    expect(result).toBeUndefined();
-  });
-
-  it('should be a pass-through if there is no jwt', async () => {
-    const result = await auth.updateDBFromToken({
-      user: {}
-    }, null, () => {});
-    expect(result).toBeUndefined();
-  });
-
-  it('should add users and acronyms to DB if they do not exist', async () => {
-    acronymService.findOrCreateList = jest.fn().mockResolvedValue();
-    userService.findOrCreate = jest.fn().mockResolvedValue();
-    userService.addAcronym = jest.fn().mockResolvedValue();
-
-    const spyFindOrCreateList = jest.spyOn(acronymService, 'findOrCreateList');
-
-    const spyFindOrCreate = jest.spyOn(userService, 'findOrCreate');
-    const spyAddAcronym = jest.spyOn(userService, 'addAcronym');
-
-    const result = await auth.updateDBFromToken({
-      user: {
-        _json: {},
-        id: userId,
-        jwt: validToken
-      }
-    }, null, () => {});
-    expect(result).toBeUndefined();
-    expect(spyFindOrCreateList).toHaveBeenCalledTimes(1);
-    expect(spyFindOrCreate).toHaveBeenCalledTimes(1);
-    expect(spyAddAcronym).toHaveBeenCalledTimes(2);
   });
 });

--- a/backend/tests/unit/components/keyCloakServiceClientMgr.spec.js
+++ b/backend/tests/unit/components/keyCloakServiceClientMgr.spec.js
@@ -130,15 +130,15 @@ describe('KeyCloakServiceClientManager fetchClient', () => {
 
 });
 
-describe('KeyCloakServiceClientManager getUser', () => {
+describe('KeyCloakServiceClientManager findUser', () => {
   it('should throw an error without username', async () => {
     const mgr = new KeyCloakServiceClientManager(realmAdminService);
-    await expect(mgr.getUser(undefined)).rejects.toThrow();
+    await expect(mgr.findUser(undefined)).rejects.toThrow();
   });
 
   it('should return a User', async () => {
     const mgr = new KeyCloakServiceClientManager(realmAdminService);
-    const r = await mgr.getUser('me@idir');
+    const r = await mgr.findUser('me@idir');
     expect(r).toBeTruthy();
     expect(r.username).toEqual('me@idir');
   });

--- a/backend/tests/unit/components/keyCloakServiceClientMgr.spec.js
+++ b/backend/tests/unit/components/keyCloakServiceClientMgr.spec.js
@@ -27,6 +27,7 @@ jest.mock('../../../src/components/realmAdminSvc', () => {
       getRoleComposites: () => { return [{ id: '456', name: 'GENERATOR', description: 'This role is.' }]; },
       getServiceAccountUser: () => { return { id: '2', 'clientId': '1' }; },
       addServiceAccountRole: () => { },
+      getUsers: () => { return [{ id: 1, username: 'me@idir' }, { id: 2, username: 'me@github' }]; },
       getClientSecret: () => { return { value: 'itsasecret' }; }
     };
   });
@@ -127,4 +128,18 @@ describe('KeyCloakServiceClientManager fetchClient', () => {
     expect(r).toBeUndefined();
   });
 
+});
+
+describe('KeyCloakServiceClientManager getUser', () => {
+  it('should throw an error without username', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    await expect(mgr.getUser(undefined)).rejects.toThrow();
+  });
+
+  it('should return a User', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    const r = await mgr.getUser('me@idir');
+    expect(r).toBeTruthy();
+    expect(r.username).toEqual('me@idir');
+  });
 });

--- a/backend/tests/unit/components/permissionHelpers.spec.js
+++ b/backend/tests/unit/components/permissionHelpers.spec.js
@@ -10,23 +10,6 @@ const sampleToken = require('./fixtures/token.json');
 
 log.level = config.get('server.logLevel');
 
-describe('filterAppAcronymRoles', () => {
-  it('should return the filtered acronym list', () => {
-    const roles = ['offline_access', 'uma_authorization', 'WEBADE_CFG_READ', 'WEBADE_CFG_READ_ALL', 'DOMO', 'MSSC'];
-    const result = permissionHelpers.filterAppAcronymRoles(roles);
-
-    expect(result).toBeTruthy();
-    expect(result).toHaveLength(2);
-  });
-
-  it('should handle an empty array', () => {
-    const roles = [];
-    const result = permissionHelpers.filterAppAcronymRoles(roles);
-    expect(result).toBeTruthy();
-    expect(result).toHaveLength(0);
-  });
-});
-
 describe('checkAcronymPermission', () => {
   const spy = jest.fn();
 

--- a/backend/tests/unit/components/realmAdminSvc.spec.js
+++ b/backend/tests/unit/components/realmAdminSvc.spec.js
@@ -535,3 +535,27 @@ describe('RealmAdminService getRoleComposites', () => {
   });
 
 });
+
+describe('RealmAdminService getUsers', () => {
+
+  it('should throw an error if no username provided', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.getUsers(undefined, '')).rejects.toThrow();
+  });
+
+  it('should return users', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onGet(`${svc.realmAdminUrl}/users?username=me@idir`).reply(204, 'yes returned');
+
+    const result = await svc.getUsers('me@idir');
+    expect(result).toBeTruthy();
+  });
+
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.getUsers('me')).rejects.toThrow();
+  });
+
+});

--- a/frontend/src/common/apiService.js
+++ b/frontend/src/common/apiService.js
@@ -107,8 +107,14 @@ export default {
 Status: ${response.status} - ${response.statusText}
 Body: ${JSON.stringify(response.data, null, 2)}`;
     } catch (e) {
-      console.log(`Failed to fetch from API - ${e}`); // eslint-disable-line no-console
-      throw e;
+      if (e.response && e.response.data) {
+        return `URL: ${route}
+      Status: ${e.response.status} - ${e.response.statusText}
+      Body: ${JSON.stringify(e.response.data, null, 2)}`;
+      } else {
+        console.log(`Failed to fetch from API - ${e}`); // eslint-disable-line no-console
+        throw e;
+      }
     }
   },
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-96

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Add a endpoint (temporary shim until we build an admin interface) that will register users to applcation acronyms.
If a acronym is not in the DB it will create it, same with user.
User must be exist in KC for this to work.

The common services team member doing this must have the new role GETOK_ADMIN_ADD_USER.

Use a GET (with a GETOK team user bearer token from the GETOK realm) on the following URL for this to work
/api/v1/acronyms/{ACRONYM}/addUser/{USERNAME}
username is llike "loneil@idir"

Best way to do this is to use the DEBUG Api Tester panel in GETOK (konami code to access)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
I added the functionality to get Keycloak users to the KeyCloakServiceClientManager class, but that is instantiated with client credentials auth information for a keycloak realm admin user. Realized we don't have config for this in GETOK for the GETOK realm, just for the YAMS realm.
Then realized that a **user** token can be used to fetch this, as long as it has the view-users scope, which our team members will have because we are realm admins. And this is a better way of controlling that access.
So to not have to add a whole bunch of new config/openshift setup/documentation for this other service client. I'm going with the user token access for getting users instead.
I left the methods in the KC manager classes as this may be useful in the common services YAMS realm at some point.