### PR TITLE
Bc fonts

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -940,6 +940,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bcgov/bc-sans": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bcgov/bc-sans/-/bc-sans-1.0.1.tgz",
+      "integrity": "sha512-4suRUBFeHcuFkwXXJu9pKJNB5Z2G3bpuLEHIq203KVCKC8KrsnqvsyUOf645TypgLwqOTOYCETiXYzfxF4gLAw=="
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -27,6 +27,7 @@
     "reinstall": "npm run purge && npm install"
   },
   "dependencies": {
+    "@bcgov/bc-sans": "^1.0.1",
     "@dsb-norge/vue-keycloak-js": "^1.1.2",
     "axios": "^0.19.2",
     "core-js": "^3.6.4",

--- a/app/frontend/src/assets/scss/style.scss
+++ b/app/frontend/src/assets/scss/style.scss
@@ -1,3 +1,12 @@
+/* Typography */
+body .v-application {
+  font-family: -apple-system, BlinkMacSystemFont, 'BCSans', ‘Noto Sans’, Verdana, Arial, sans-serif !important;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-size: 1em;
+  line-height: 1.25;
+}
+
 /* sticky footer */
 html,
 body {

--- a/app/frontend/src/assets/scss/style.scss
+++ b/app/frontend/src/assets/scss/style.scss
@@ -1,6 +1,6 @@
 /* Typography */
 body .v-application {
-  font-family: -apple-system, BlinkMacSystemFont, 'BCSans', ‘Noto Sans’, Verdana, Arial, sans-serif !important;
+  font-family: -apple-system, BlinkMacSystemFont, "BCSans", "Noto Sans", Verdana, Arial, sans-serif !important;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-size: 1em;

--- a/app/frontend/src/assets/scss/style.scss
+++ b/app/frontend/src/assets/scss/style.scss
@@ -4,7 +4,7 @@ body .v-application {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-size: 1em;
-  line-height: 1.25;
+  line-height: 1.5em;
 }
 
 /* sticky footer */

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -1,4 +1,5 @@
 import 'nprogress/nprogress.css';
+import '@bcgov/bc-sans/css/BCSans.css';
 import '@/assets/scss/style.scss';
 
 import axios from 'axios';


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Use BC fonts in frontend UI
supports ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-870

as discussed, i've implemented this with the bc-sans npm package.
if we dont like this, we can put the fonts in our public/assests

we might need to use !important to overide vuetify (sparingly)
alternative could be to add a custom class name (like .bcgov) to the body tag (in index.html) 
and then use inheritance.
i think vuetify does define the font on some of the headings. maybe we override these on an individual basis.

i also think the bcsans font doesnt look very smooth (on firefox anyway)


## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->
New feature (non-breaking change which adds functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->