### PR TITLE
Refactor requestForm to use auth store and Documentation

### DIFF
--- a/app/frontend/README.md
+++ b/app/frontend/README.md
@@ -22,6 +22,8 @@ The material design framework Vuetify is used for design and layout. All additio
 
 The Vuex state management system is an integral part of the frontend application. It maintains a centralized store for all the components in the app. The location of the store in the project structure is `./src/store`. See the [Vuex docs](https://vuex.vuejs.org/) for more information.
 
+Our Vuex store leverages [dynamic module registration](https://vuex.vuejs.org/guide/modules.html#dynamic-module-registration) in order to allow for certain modules to be loaded after store creation. This allows us to start the application sooner, and allows for better code separation in webpack bundling. At this time, the auth module must be loaded after the Keycloak plugin has fully loaded. Other modules may potentially follow this dynamic registration pattern if it makes sense.
+
 #### Vue Router
 
 Vue Router is used for Single Page App routing. See the [Vue Router docs](https://router.vuejs.org/) for more information. We are not using history mode in order to ensure network pathing remains consistent.
@@ -51,7 +53,18 @@ Unit tests are written in [Jest](https://jestjs.io/).
 
 [Vue Test Utils](https://vue-test-utils.vuejs.org/) is included (scaffolded through Vue CLI) to facilitate unit test writing for the Vue components.
 
-See [Run your unit tests](#run-your-unit-tests) below for details on executing tests
+See [Run your unit tests](#run-your-unit-tests) below for details on executing tests.
+
+### Writing Unit Tests
+
+For most components, we will want to be shallow mounting them in order to avoid accidentally testing for behavior across different components. Components which contain children components should be stubbed out where possible.
+
+As our codebase uses [dynamic module registration](https://vuex.vuejs.org/guide/modules.html#dynamic-module-registration), unit tests which need the store will need to one of the following:
+
+1. Instantiate a new vuex store with the appropriate values as part of the constructor
+2. Create an empty vuex store and then register a mocked vuex store module for the specific unit test environment
+
+While both methods effectively achieve the same goal of setting the vuex store mock to be in the right state, we suggest using the second option as it can provide slightly more flexibility with unit testing.
 
 ## Project scripts to run locally
 

--- a/app/frontend/src/assets/scss/style.scss
+++ b/app/frontend/src/assets/scss/style.scss
@@ -39,7 +39,11 @@ body > .v-content {
   padding: 12px 32px !important;
   text-align: center;
   text-decoration: none;
-  cursor: pointer;
+}
+
+.v-btn.v-btn--disabled {
+  background-color: #eee;
+  color: #777;
 }
 
 .BC-Gov-PrimaryButton:hover,

--- a/app/frontend/src/components/RequestForm.vue
+++ b/app/frontend/src/components/RequestForm.vue
@@ -88,8 +88,8 @@
       </v-row>
     </v-form>
     <div class="justify-center pb-8">
-      <v-btn class="BC-Gov-PrimaryButton light float-left" text @click="cancel()">Cancel</v-btn>
-      <v-btn class="BC-Gov-PrimaryButton float-right" text @click="postRegistrationForm()">Submit</v-btn>
+      <v-btn class="request-form-cancel-btn BC-Gov-PrimaryButton light float-left" text @click="cancel()">Cancel</v-btn>
+      <v-btn class="request-form-submit-btn BC-Gov-PrimaryButton float-right" text @click="postRegistrationForm()">Submit</v-btn>
     </div>
 
     <BaseDialog v-bind:show="errorOccurred" @close-dialog="errorOccurred = false">
@@ -120,13 +120,16 @@
 </template>
 
 <script>
-import Vue from 'vue';
+import { mapGetters } from 'vuex';
 
 import emailService from '@/services/emailService';
 import { FieldValidations } from '@/utils/constants.js';
 
 export default {
   name: 'RequestForm',
+  computed: {
+    ...mapGetters('auth', ['tokenParsed'])
+  },
   data() {
     return {
       applicationAcronymRules: [
@@ -142,8 +145,8 @@ export default {
       form: {
         applicationAcronym: '',
         comments: '',
-        from: Vue.prototype.$keycloak.tokenParsed.email,
-        idir: Vue.prototype.$keycloak.tokenParsed.preferred_username
+        from: '',
+        idir: ''
       },
       fieldValidations: FieldValidations,
       registerSuccess: false,
@@ -154,7 +157,6 @@ export default {
     cancel() {
       this.$router.push({ name: 'About' });
     },
-
     postRegistrationForm() {
       this.resetState();
       if (this.$refs.form.validate()) {
@@ -170,7 +172,12 @@ export default {
           });
       }
     },
-
+    resetForm() {
+      this.form.applicationAcronym = '';
+      this.form.comments = '';
+      this.form.from = this.tokenParsed.email;
+      this.form.idir = this.tokenParsed.preferred_username;
+    },
     resetState() {
       this.errorOccurred = false;
       this.registerSuccess = false;
@@ -178,6 +185,7 @@ export default {
   },
   mounted() {
     this.resetState();
+    this.resetForm();
   }
 };
 </script>

--- a/app/frontend/src/components/base/BaseAuthButton.vue
+++ b/app/frontend/src/components/base/BaseAuthButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="keycloakReady">
-    <v-btn v-if="authenticated" color="white" class="login-btn" @click="logout" outlined>
+    <v-btn v-if="authenticated" color="white" class="logout-btn" @click="logout" outlined>
       <v-icon :left="$vuetify.breakpoint.smAndUp">mdi-logout</v-icon>
       <span v-if="$vuetify.breakpoint.smAndUp">Logout</span>
     </v-btn>

--- a/app/frontend/tests/unit/App.spec.js
+++ b/app/frontend/tests/unit/App.spec.js
@@ -1,0 +1,26 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import Vuetify from 'vuetify';
+
+import router from '@/router';
+import App from '@/App.vue';
+
+const localVue = createLocalVue();
+localVue.use(router);
+localVue.use(Vuetify);
+
+describe('App.vue', () => {
+  it('renders', () => {
+    const wrapper = shallowMount(App, {
+      localVue,
+      stubs: [
+        'BCGovHeader',
+        'BCGovNavBar',
+        'BCGovFooter'
+      ]
+    });
+
+    expect(wrapper.text()).toMatch('');
+    expect(wrapper.html()).toMatch('v-app');
+    expect(wrapper.html()).toMatch('router-view');
+  });
+});

--- a/app/frontend/tests/unit/components/RequestForm.spec.js
+++ b/app/frontend/tests/unit/components/RequestForm.spec.js
@@ -1,0 +1,135 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import Vuetify from 'vuetify';
+import Vuex from 'vuex';
+
+import RequestForm from '@/components/RequestForm.vue';
+import emailService from '@/services/emailService';
+
+const localVue = createLocalVue();
+localVue.use(Vuetify);
+localVue.use(Vuex);
+
+describe('RequestForm.vue', () => {
+  const sendRegEmailSpy = jest.spyOn(emailService, 'sendRegistrationEmail');
+  let store;
+
+  beforeEach(() => {
+    sendRegEmailSpy.mockReset();
+    store = new Vuex.Store();
+  });
+
+  it('renders with correct initial form state', () => {
+    const email = 'email';
+    const idir = 'user@idir';
+    store.registerModule('auth', {
+      namespaced: true,
+      getters: {
+        tokenParsed: () => {
+          return {
+            email: email,
+            preferred_username: idir
+          };
+        }
+      }
+    });
+
+    const wrapper = shallowMount(RequestForm, {
+      store,
+      localVue,
+      stubs: ['BaseDialog']
+    });
+
+    expect(wrapper.text()).toContain('Request Account');
+    expect(wrapper.vm.form.from).toMatch(email);
+    expect(wrapper.vm.form.idir).toMatch(idir);
+  });
+
+  it('success dialog can appear when sendRegistrationEmail succeeds', async () => {
+    sendRegEmailSpy.mockResolvedValue({});
+    store.registerModule('auth', {
+      namespaced: true,
+      getters: {
+        tokenParsed: () => {
+          return {
+            email: 'email',
+            preferred_username: 'user@idir'
+          };
+        }
+      }
+    });
+
+    const wrapper = shallowMount(RequestForm, {
+      store,
+      localVue,
+      stubs: ['BaseDialog']
+    });
+    wrapper.vm.$refs.form.validate = () => true;
+    await wrapper.vm.postRegistrationForm();
+    await localVue.nextTick();
+
+    expect(wrapper.text()).toContain('Request Account');
+    expect(wrapper.vm.errorOccurred).toBeFalsy();
+    expect(wrapper.vm.registerSuccess).toBeTruthy();
+    expect(sendRegEmailSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('error dialog can appear when sendRegistrationEmail fails', async () => {
+    sendRegEmailSpy.mockRejectedValue({});
+    store.registerModule('auth', {
+      namespaced: true,
+      getters: {
+        tokenParsed: () => {
+          return {
+            email: 'email',
+            preferred_username: 'user@idir'
+          };
+        }
+      }
+    });
+
+    const wrapper = shallowMount(RequestForm, {
+      store,
+      localVue,
+      stubs: ['BaseDialog']
+    });
+    wrapper.vm.$refs.form.validate = () => true;
+    await wrapper.vm.postRegistrationForm();
+    await localVue.nextTick();
+
+    expect(wrapper.text()).toContain('Request Account');
+    expect(wrapper.vm.registerSuccess).toBeFalsy();
+    expect(wrapper.vm.errorOccurred).toBeTruthy();
+    expect(sendRegEmailSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel redirects to about page', async () => {
+    const routerPushSpy = jest.fn();
+    store.registerModule('auth', {
+      namespaced: true,
+      getters: {
+        tokenParsed: () => {
+          return {
+            email: 'email',
+            preferred_username: 'user@idir'
+          };
+        }
+      }
+    });
+
+    const wrapper = shallowMount(RequestForm, {
+      store,
+      localVue,
+      mocks: {
+        $router: {
+          push: routerPushSpy
+        }
+      },
+      stubs: ['BaseDialog']
+    });
+    await wrapper.vm.cancel();
+    await localVue.nextTick();
+
+    expect(routerPushSpy).toHaveBeenCalledTimes(1);
+    expect(routerPushSpy).toHaveBeenCalledWith({ name: 'About' });
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR refactors the RequestForm component to use the auth vuex store layer instead of directly invoking the Keycloak plugin. This change was required in order to more cleanly do unit testing for any component which needs to ask about the current user.

**Other changes:**
- Add disabled button style as per design guidelines
- Fix typo in logout class name in BaseAuthButton
- Add some documentation on Vuex unit testing and considerations
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-824](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-824)
[SHOWCASE-872](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-872)
[SHOWCASE-889](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-889)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->