### PR TITLE
Add in KC management

### DIFF
--- a/app/config/default.json
+++ b/app/config/default.json
@@ -33,15 +33,15 @@
     "keycloak": {
       "dev": {
         "endpoint": "https://sso-dev.pathfinder.gov.bc.ca",
-        "realm": "98r0z7rz"
+        "realm": "jbd6rnxw"
       },
       "test": {
         "endpoint": "https://sso-test.pathfinder.gov.bc.ca",
-        "realm": "98r0z7rz"
+        "realm": "jbd6rnxw"
       },
       "prod": {
         "endpoint": "https://sso.pathfinder.gov.bc.ca",
-        "realm": "98r0z7rz"
+        "realm": "jbd6rnxw"
       }
     },
     "webAde": {

--- a/app/frontend/src/services/userService.js
+++ b/app/frontend/src/services/userService.js
@@ -22,7 +22,7 @@ export default {
    */
   getServiceClients(keycloakId) {
     if (keycloakId && validator.isUUID(keycloakId)) {
-      return getokAxios().get(`/users/${keycloakId}/acronyms/clients`);
+      return getokAxios().get(`/users/${keycloakId}/acronyms/clients`, { timeout: 30000 });
     } else {
       return Promise.reject('keycloakId must be a valid UUID');
     }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1286,6 +1286,29 @@
         "deep-equal": "^1.0.1"
       }
     },
+    "axios-oauth-client": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/axios-oauth-client/-/axios-oauth-client-1.2.1.tgz",
+      "integrity": "sha512-Fbg4I68R4KxBDlEUQPKNXEZtbZs3xfL98Tr5r3Xcl7LKvHJssg1v2KKnQ3QARCp+FK1IsOymXvHluPaQZBL10w==",
+      "requires": {
+        "qs": "^6.8.0"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.9.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+        }
+      }
+    },
+    "axios-token-interceptor": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/axios-token-interceptor/-/axios-token-interceptor-0.2.0.tgz",
+      "integrity": "sha512-la74OEsXBH1IS9yI6p2oTIynPtBzs0PVUSOwOBgFg2kBwTeDqQ+YJ6jaOWxsTYyqJO510OzHTfnzAn3GFuf9xA==",
+      "requires": {
+        "lock": "^1.1.0"
+      }
+    },
     "babel-eslint": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
@@ -7202,6 +7225,11 @@
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
       }
+    },
+    "lock": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lock/-/lock-1.1.0.tgz",
+      "integrity": "sha1-UxV0mdFlOxNspmRRBx/KYVcD+lU="
     },
     "lodash": {
       "version": "4.17.15",

--- a/app/package.json
+++ b/app/package.json
@@ -43,6 +43,8 @@
   },
   "dependencies": {
     "api-problem": "6.0.1",
+    "axios-oauth-client": "^1.2.1",
+    "axios-token-interceptor": "^0.2.0",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "config": "^3.3.0",

--- a/app/src/components/keyCloakServiceClientMgr.js
+++ b/app/src/components/keyCloakServiceClientMgr.js
@@ -1,0 +1,173 @@
+const log = require('npmlog');
+
+const { acronymService } = require('../services');
+
+const COMMON_SVC_COMPOSITE = 'COMMON_SERVICES';
+
+class KeyCloakServiceClientManager {
+  constructor(realmAdminService) {
+    if (!realmAdminService) {
+      log.error('KeyCloakServiceClientManager - no realm admin service provided.');
+      throw new Error('KeyCloakServiceClientManager requires RealmAdminService.  Check configuration.');
+    }
+    this.svc = realmAdminService;
+  }
+
+  async manage({ applicationAcronym, applicationName, applicationDescription, commonServices }) {
+    log.info('KeyCloakServiceClientManager.manage ', `${applicationAcronym}, ${applicationName}, ${applicationDescription}, [${commonServices}]`);
+    if (!applicationAcronym) {
+      log.error('KeyCloakServiceClientManager - no applicationAcronymprovided.');
+      throw new Error('Cannot manage service clients in KeyCloak realm: applicationAcronym required.');
+    }
+    if (!applicationName) {
+      log.error('KeyCloakServiceClientManager - no applicationName provided.');
+      throw new Error('Cannot manage service clients in KeyCloak realm: applicationName required.');
+    }
+    if (!applicationDescription) {
+      log.error('KeyCloakServiceClientManager - no applicationDescription provided.');
+      throw new Error('Cannot manage service clients in KeyCloak realm: applicationDescription required.');
+    }
+    if (!commonServices) {
+      log.error('KeyCloakServiceClientManager - no commonServices provided.');
+      throw new Error('Cannot manage service clients in KeyCloak realm: commonServices required.');
+    }
+
+    const clientId = `${applicationAcronym.toUpperCase()}_SERVICE_CLIENT`;
+    const clientRoleName = COMMON_SVC_COMPOSITE;
+
+    const clients = await this.svc.getClients();
+    let serviceClient = clients.find(x => x.clientId === clientId);
+    if (!serviceClient) {
+      serviceClient = await this.svc.createClient(clientId, applicationName, applicationDescription);
+    } else {
+      // may have changed the name and description...
+      serviceClient = await this.svc.updateClientDetails(serviceClient, applicationName, applicationDescription);
+    }
+
+    // get all the selected common services and their roles
+    // add roles to the lob COMMON_SERVICE role
+    // commonServices is an array of clientIds
+
+    // was an inline function, but that's a code smell...
+    // eslint-disable-next-line no-inner-declarations
+    function getCmnSrvClient(clientId) {
+      return clients.find(y => { return clientId === y.clientId; });
+    }
+
+    let commonServiceRoles = [];
+    if (commonServices && commonServices.length > 0) {
+      for (const cmnSrvClientId of commonServices) {
+        const cmnSrvClient = getCmnSrvClient(cmnSrvClientId);
+        if (cmnSrvClient) {
+          const cmnSrvClientRoles = await this.svc.getClientRoles(cmnSrvClient.id);
+          commonServiceRoles = commonServiceRoles.concat(cmnSrvClientRoles);
+        }
+      }
+    }
+
+    // this is an easier way than reading which roles and composites are in place.
+    // just remove the service client role (if exists) and start from scratch each time.
+    let clientRoles = await this.svc.getClientRoles(serviceClient.id);
+    let commonServicesRole = clientRoles.find(x => x.name === clientRoleName);
+    if (commonServicesRole) {
+      await this.svc.removeClientRole(serviceClient.id, clientRoleName);
+    }
+
+    // add in new role...
+    clientRoles = await this.svc.addClientRole(serviceClient.id, clientRoleName);
+    // get the common service role for service client
+    commonServicesRole = clientRoles.find(x => x.name === clientRoleName);
+
+    // pass in the list of roles from the common services (if any).
+    // this will set the composite roles, the service client will have access to all of these common service roles.
+    await this.svc.setRoleComposites(serviceClient, clientRoleName, commonServiceRoles);
+
+    // get the service account user...
+    const serviceAccountUser = await this.svc.getServiceAccountUser(serviceClient.id);
+    //  add the service account role to them...
+    await this.svc.addServiceAccountRole(serviceAccountUser.id, serviceClient.id, commonServicesRole);
+
+    // now go get the lob client secret, and we will return it
+    const clientSecret = await this.svc.getClientSecret(serviceClient.id);
+
+    // Update the acronym details stored in the GETOK DB
+    await acronymService.updateDetails(applicationAcronym, applicationName, applicationDescription);
+
+    // return information for logging in as this new service client.
+    return {
+      generatedPassword: clientSecret.value,
+      generatedServiceClient: serviceClient.clientId,
+      oidcTokenUrl: this.svc.tokenUrl
+    };
+  }
+
+  async fetchClients(applicationAcronymList) {
+    log.info('KeyCloakServiceClientManager.fetchClients', applicationAcronymList);
+    if (!applicationAcronymList || !Array.isArray(applicationAcronymList)) {
+      log.error('KeyCloakServiceClientManager.fetchClients', 'No applicationAcronymList provided.');
+      throw new Error('Cannot find service clients in KeyCloak realm: applicationAcronymList array required.');
+    }
+    if (!applicationAcronymList.length) {
+      log.error('KeyCloakServiceClientManager.fetchClients', 'No applicationAcronymList contents provided.');
+      throw new Error('Cannot find service clients in KeyCloak realm: applicationAcronymList containing acronyms required.');
+    }
+
+    const clients = await this.svc.getClients();
+    const clientIdsNeeded = applicationAcronymList.map(acr => `${acr.toUpperCase()}_SERVICE_CLIENT`);
+    const serviceClientList = clients.filter(x => clientIdsNeeded.includes(x.clientId));
+
+    const unresolvedPromises = serviceClientList.map(sc => this.makeClientDetails(sc));
+    return await Promise.all(unresolvedPromises);
+  }
+
+  async makeClientDetails(serviceClient) {
+    if (serviceClient && serviceClient.id) {
+      // get the service account user.
+      const serviceAccountUser = await this.svc.getServiceAccountUser(serviceClient.id);
+      const roleComposites = await this.svc.getRoleComposites(serviceClient.id, COMMON_SVC_COMPOSITE);
+
+      // return desired info for the GETOK API for this service client.
+      const detailObject = {
+        id: serviceClient.id,
+        clientId: serviceClient.clientId,
+        enabled: serviceClient.enabled,
+        name: serviceClient.name,
+        description: serviceClient.description,
+        serviceAccountEmail: serviceAccountUser ? serviceAccountUser.email : ''
+      };
+      if (roleComposites && roleComposites.length) {
+        detailObject.commonServiceRoles = roleComposites
+          .filter(role => role.name !== 'uma_protection')
+          .map(role => ({
+            name: role.name,
+            description: role.description
+          }));
+      }
+      return detailObject;
+
+    } else {
+      log.debug('KeyCloakServiceClientManager.fetchClient', 'No service client id');
+      return undefined;
+    }
+  }
+
+  async findUser(username) {
+    log.info('KeyCloakServiceClientManager.findUser', username);
+    if (!username) {
+      log.error('KeyCloakServiceClientManager.findUser', 'No user provided.');
+      throw new Error('Cannot get a user in KeyCloak realm: username required.');
+    }
+
+    const users = await this.svc.getUsers(username);
+
+    if (users && users.length) {
+      // Can only be one user by identified username (idir or github or whatever)
+      return users[0];
+    } else {
+      log.debug('KeyCloakServiceClientManager.findUser', `No user found for ${username}`);
+      return undefined;
+    }
+  }
+}
+
+module.exports = KeyCloakServiceClientManager;

--- a/app/src/components/realmAdminSvc.js
+++ b/app/src/components/realmAdminSvc.js
@@ -1,0 +1,409 @@
+const axios = require('axios');
+const log = require('npmlog');
+const oauth = require('axios-oauth-client');
+const tokenProvider = require('axios-token-interceptor');
+
+
+class RealmAdminService {
+  constructor({ realmId, realmBaseUrl, clientId, clientSecret }) {
+    log.info('RealmAdminService ', `${realmId}, ${realmBaseUrl}, ${clientId}, secret`);
+    if (!realmId || !realmBaseUrl || !clientId || !clientSecret) {
+      log.error('RealmAdminService - invalid configuration.');
+      throw new Error('RealmAdminService is not configured.  Check configuration.');
+    }
+
+    this.tokenUrl = `${realmBaseUrl}/auth/realms/${realmId}/protocol/openid-connect/token`;
+    this.realmAdminUrl = `${realmBaseUrl}/auth/admin/realms/${realmId}`;
+    this.realmId = realmId;
+
+    this.axios = axios.create();
+    this.axios.interceptors.request.use(
+      // Wraps axios-token-interceptor with oauth-specific configuration,
+      // fetches the token using the desired claim method, and caches
+      // until the token expires
+      oauth.interceptor(tokenProvider, oauth.client(axios.create(), {
+        url: this.tokenUrl,
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: clientSecret,
+        scope: ''
+      }))
+    );
+  }
+
+  async getRealm() {
+    const response = await this.axios.get(this.realmAdminUrl)
+      .catch(e => {
+        log.error('RealmAdminService.getRealm', JSON.stringify(e));
+        throw e;
+      });
+    return response.data;
+  }
+
+  async getClients() {
+    const response = await this.axios.get(`${this.realmAdminUrl}/clients`)
+      .catch(e => {
+        log.error('RealmAdminService.getClients', JSON.stringify(e));
+        throw e;
+      });
+    return response.data;
+  }
+
+  async getClient(id) {
+    if (!id) {
+      log.error('RealmAdminService getClient id parameter is null.');
+      throw new Error('Cannot get client: id parameter cannot be null.');
+    }
+    const response = await this.axios.get(`${this.realmAdminUrl}/clients/${id}`)
+      .catch(e => {
+        log.error('RealmAdminService.getClient', JSON.stringify(e));
+        throw e;
+      });
+    return response.data;
+  }
+
+  async createClient(clientId, name, description) {
+    if (!clientId || !name || !description) {
+      log.error('RealmAdminService createClient a parameter is null.');
+      throw new Error('Cannot create client: clientId, name, and description cannot be null.');
+    }
+    const defaults = {
+      'clientId': '',
+      'name': '',
+      'description': '',
+      'authorizationServicesEnabled': true,
+      'surrogateAuthRequired': false,
+      'enabled': true,
+      'clientAuthenticatorType': 'client-secret',
+      'redirectUris': [],
+      'webOrigins': [],
+      'notBefore': 0,
+      'bearerOnly': false,
+      'consentRequired': false,
+      'standardFlowEnabled': false,
+      'implicitFlowEnabled': false,
+      'directAccessGrantsEnabled': false,
+      'serviceAccountsEnabled': true,
+      'publicClient': false,
+      'frontchannelLogout': false,
+      'protocol': 'openid-connect',
+      'attributes': {
+        'saml.assertion.signature': 'false',
+        'saml.multivalued.roles': 'false',
+        'saml.force.post.binding': 'false',
+        'saml.encrypt': 'false',
+        'saml.server.signature': 'false',
+        'saml.server.signature.keyinfo.ext': 'false',
+        'exclude.session.state.from.auth.response': 'false',
+        'saml_force_name_id_format': 'false',
+        'saml.client.signature': 'false',
+        'tls.client.certificate.bound.access.tokens': 'false',
+        'saml.authnstatement': 'false',
+        'display.on.consent.screen': 'false',
+        'saml.onetimeuse.condition': 'false'
+      },
+      'authenticationFlowBindingOverrides': {},
+      'fullScopeAllowed': false,
+      'nodeReRegistrationTimeout': -1,
+      'protocolMappers': [
+        {
+          'name': 'Client ID',
+          'protocol': 'openid-connect',
+          'protocolMapper': 'oidc-usersessionmodel-note-mapper',
+          'consentRequired': false,
+          'config': {
+            'user.session.note': 'clientId',
+            'id.token.claim': 'true',
+            'access.token.claim': 'true',
+            'claim.name': 'clientId',
+            'jsonType.label': 'String'
+          }
+        },
+        {
+          'name': 'Client Host',
+          'protocol': 'openid-connect',
+          'protocolMapper': 'oidc-usersessionmodel-note-mapper',
+          'consentRequired': false,
+          'config': {
+            'user.session.note': 'clientHost',
+            'id.token.claim': 'true',
+            'access.token.claim': 'true',
+            'claim.name': 'clientHost',
+            'jsonType.label': 'String'
+          }
+        },
+        {
+          'name': 'Client IP Address',
+          'protocol': 'openid-connect',
+          'protocolMapper': 'oidc-usersessionmodel-note-mapper',
+          'consentRequired': false,
+          'config': {
+            'user.session.note': 'clientAddress',
+            'id.token.claim': 'true',
+            'access.token.claim': 'true',
+            'claim.name': 'clientAddress',
+            'jsonType.label': 'String'
+          }
+        }
+      ],
+      'defaultClientScopes': [
+        'web-origins',
+        'roles'
+      ],
+      'optionalClientScopes': [],
+      'access': {
+        'view': true,
+        'configure': true,
+        'manage': true
+      }
+    };
+
+    const applicationDetails = {
+      'clientId': clientId,
+      'name': name,
+      'description': description
+    };
+
+    const requestBody = { ...defaults, ...applicationDetails };
+    const response = await this.axios.post(
+      `${this.realmAdminUrl}/clients`,
+      JSON.stringify(requestBody),
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    ).catch(e => {
+      log.error('RealmAdminService.createClient', JSON.stringify(e));
+      throw e;
+    });
+
+    // check for 201, get the location header... it'll have the id
+    const resourceUrl = response.headers.location;
+    const fetchResponse = await this.axios.get(resourceUrl);
+    return fetchResponse.data;
+  }
+
+  async updateClientDetails(client, name, description) {
+    if (!client) {
+      log.error('RealmAdminService updateClientDetails no client provided.');
+      throw new Error('Cannot update client: client cannot be null.');
+    }
+
+    if (!name || !description) {
+      log.error('RealmAdminService updateClientDetails a parameter is null.');
+      throw new Error('Cannot update client: name, and description cannot be null.');
+    }
+
+    const applicationDetails = {
+      'name': name,
+      'description': description
+    };
+
+    const requestBody = { ...client, ...applicationDetails };
+    await this.axios.put(
+      `${this.realmAdminUrl}/clients/${client.id}`,
+      JSON.stringify(requestBody),
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    ).catch(e => {
+      log.error('RealmAdminService.updateClientDetails', JSON.stringify(e));
+      throw e;
+    });
+    // response should be 204... go fetch the updated client...
+    return await this.getClient(client.id);
+  }
+
+  async getClientSecret(id) {
+    if (!id) {
+      log.error('RealmAdminService getClientSecret id parameter is null.');
+      throw new Error('Cannot get client secret: id parameter cannot be null.');
+    }
+
+    const response = await this.axios.get(`${this.realmAdminUrl}/clients/${id}/client-secret`
+    ).catch(e => {
+      log.error('RealmAdminService.getClientSecret', JSON.stringify(e));
+      throw e;
+    });
+    return response.data;
+  }
+
+  async getServiceAccountUser(id) {
+    if (!id) {
+      log.error('RealmAdminService getServiceAccountUser id parameter is null.');
+      throw new Error('Cannot get client service account user: id parameter cannot be null.');
+    }
+
+    const response = await this.axios.get(`${this.realmAdminUrl}/clients/${id}/service-account-user`)
+      .catch(e => {
+        log.error('RealmAdminService.getServiceAccountUser', JSON.stringify(e));
+        throw e;
+      });
+    return response.data;
+  }
+
+  async getClientRoles(id) {
+    if (!id) {
+      log.error('RealmAdminService getClientRoles id parameter is null.');
+      throw new Error('Cannot get client roles: id parameter cannot be null.');
+    }
+
+    const response = await this.axios.get(`${this.realmAdminUrl}/clients/${id}/roles`
+    ).catch(e => {
+      log.error('RealmAdminService.getClientRoles', JSON.stringify(e));
+      throw e;
+    });
+    return response.data;
+  }
+
+  async removeClientRole(id, roleName) {
+    if (!id) {
+      log.error('RealmAdminService removeClientRole id parameter is null.');
+      throw new Error('Cannot remove client role: id parameter cannot be null.');
+    }
+    if (!roleName) {
+      log.error('RealmAdminService removeClientRole roleName parameter is null.');
+      throw new Error('Cannot remove client role: roleName parameter cannot be null.');
+    }
+
+    const response = await this.axios.delete(
+      `${this.realmAdminUrl}/clients/${id}/roles/${roleName}`
+    ).catch(e => {
+      log.error('RealmAdminService.removeClientRole', JSON.stringify(e));
+      throw e;
+    });
+    return response;
+  }
+
+  async addClientRole(id, roleName) {
+    if (!id) {
+      log.error('RealmAdminService addClientRole id parameter is null.');
+      throw new Error('Cannot add client role: id parameter cannot be null.');
+    }
+    if (!roleName) {
+      log.error('RealmAdminService addClientRole roleName parameter is null.');
+      throw new Error('Cannot add client role: roleName parameter cannot be null.');
+    }
+
+    const requestBody = {
+      'name': roleName,
+      'composite': true,
+      'clientRole': true,
+      'attributes': {}
+    };
+    await this.axios.post(
+      `${this.realmAdminUrl}/clients/${id}/roles`,
+      JSON.stringify(requestBody),
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    ).catch(e => {
+      log.error('RealmAdminService.addClientRole', JSON.stringify(e));
+      throw e;
+    });
+    //response should be 201 created... return the list of roles
+    return await this.getClientRoles(id);
+  }
+
+  async addServiceAccountRole(serviceAccountUserId, clientId, role) {
+    if (!serviceAccountUserId) {
+      log.error('RealmAdminService addServiceAccountRole serviceAccountUserId parameter is null.');
+      throw new Error('Cannot add service account role: serviceAccountUserId parameter cannot be null.');
+    }
+    if (!clientId) {
+      log.error('RealmAdminService addServiceAccountRole clientId parameter is null.');
+      throw new Error('Cannot add service account role: clientId parameter cannot be null.');
+    }
+    if (!role) {
+      log.error('RealmAdminService addServiceAccountRole role parameter is null.');
+      throw new Error('Cannot add service account role: role parameter cannot be null.');
+    }
+
+    const response = await this.axios.post(
+      `${this.realmAdminUrl}/users/${serviceAccountUserId}/role-mappings/clients/${clientId}`,
+      JSON.stringify([role]),
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    ).catch(e => {
+      log.error('RealmAdminService.addServiceAccountRole', JSON.stringify(e));
+      throw e;
+    });
+    return response.data;
+  }
+
+  async getRoleComposites(clientId, roleName) {
+    if (!clientId) {
+      log.error('RealmAdminService.getRoleComposites', 'clientId parameter is null.');
+      throw new Error('Cannot get role composites for client roles: clientId parameter cannot be null.');
+    }
+    if (!roleName) {
+      log.error('RealmAdminService.getRoleComposites', 'roleName parameter is null.');
+      throw new Error('Cannot get service composites for client roles: roleName parameter cannot be null.');
+    }
+
+    const url = `${this.realmAdminUrl}/clients/${clientId}/roles/${roleName}/composites`;
+    const response = await this.axios.get(url)
+      .catch(e => {
+        log.error('RealmAdminService.getRoleComposites', JSON.stringify(e));
+        throw e;
+      });
+    return response.data;
+  }
+
+  async setRoleComposites(client, roleName, roles) {
+    if (!client) {
+      log.error('RealmAdminService setRoleComposites client parameter is null.');
+      throw new Error('Cannot add service roles to client roles: client parameter cannot be null.');
+    }
+    if (!roleName) {
+      log.error('RealmAdminService setRoleComposites roleName parameter is null.');
+      throw new Error('Cannot add service roles to client roles: roleName parameter cannot be null.');
+    }
+    if (!roles) {
+      log.error('RealmAdminService setRoleComposites roles parameter is null.');
+      throw new Error('Cannot add service roles to client roles: roles parameter cannot be null.');
+    }
+
+    const response = await this.axios.post(
+      `${this.realmAdminUrl}/clients/${client.id}/roles/${roleName}/composites`,
+      JSON.stringify(roles),
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    ).catch(e => {
+      log.error('RealmAdminService.setRoleComposites', JSON.stringify(e));
+      throw e;
+    });
+    //204 created...
+    return response;
+  }
+
+  // Get from the users list with the username query param. If we want to be able to filter by more can refactor this method
+  // to take in search parameters. https://www.keycloak.org/docs-api/5.0/rest-api/index.html#_users_resource
+  async getUsers(username) {
+    if (!username) {
+      log.error('RealmAdminService.getUsers', 'username parameter is null.');
+      throw new Error('Cannot get users: username parameter cannot be null.');
+    }
+
+    const url = `${this.realmAdminUrl}/users?username=${username}`;
+    const response = await this.axios.get(url)
+      .catch(e => {
+        log.error('RealmAdminService.getUsers', JSON.stringify(e));
+        throw e;
+      });
+    return response.data;
+  }
+}
+
+module.exports = RealmAdminService;

--- a/app/src/components/users.js
+++ b/app/src/components/users.js
@@ -1,3 +1,7 @@
+const config = require('config');
+const KeyCloakServiceClientManager = require('./keyCloakServiceClientMgr');
+const log = require('npmlog');
+const RealmAdminService = require('./realmAdminSvc');
 const { userService } = require('../services');
 
 const users = {
@@ -25,32 +29,52 @@ const users = {
     const user = await userService.find(keycloakId);
     if (!user) return null;
 
-    const acronyms = await userService.userAcronymList(keycloakId);
-    if (!acronyms || !Array.isArray(acronyms) || !acronyms.length) {
+    const acronymsFromDb = await userService.userAcronymList(keycloakId);
+    if (!acronymsFromDb || !Array.isArray(acronymsFromDb) || !acronymsFromDb.length) {
       return [];
     }
+    const acronyms = acronymsFromDb.map(acr => acr.acronym);
+    log.debug('getUserAcronymClients', `Acronyms for user: ${JSON.stringify(acronyms)}`);
 
-    return [{
-      acronym: 'WORG',
-      dev: {
-        clientId: 'WORG_SERVICE_CLIENT',
-        enabled: true
-      },
-      test: {
-        clientId: 'WORG_SERVICE_CLIENT',
-        enabled: true
-      }
-    }, {
-      acronym: 'MSSC',
-      dev: {
-        clientId: 'MSSC_SERVICE_CLIENT',
-        enabled: true
-      },
-      test: {
-        clientId: 'MSSC_SERVICE_CLIENT',
-        enabled: false
-      }
-    }];
+    let [devClients, testClients, prodClients] = await Promise.all([
+      users.getClientsFromEnv('dev', acronyms),
+      users.getClientsFromEnv('test', acronyms),
+      users.getClientsFromEnv('prod', acronyms)
+    ]);
+
+    // This might be able to be better one-lined with map/reduce, but just not worth the time
+    const clientList = [];
+    acronyms.forEach(acr => {
+      const dc = devClients.find(cl => cl.clientId === `${acr}_SERVICE_CLIENT`);
+      const tc = testClients.find(cl => cl.clientId === `${acr}_SERVICE_CLIENT`);
+      const pc = prodClients.find(cl => cl.clientId === `${acr}_SERVICE_CLIENT`);
+      clientList.push({
+        acronym: acr,
+        dev: dc ? dc : null,
+        test: tc ? tc : null,
+        prod: pc ? pc : null
+      });
+    });
+    return clientList;
+  },
+  /**
+   * @function getClientsFromEnv
+   * Utility function to call the KC service to get clients for each realm
+   * @param {string} kcEnv The KC env
+   * @param {string} acronyms The acronyms to get clients for
+   * @returns {object[]} An array of service clients
+   */
+  getClientsFromEnv: async (kcEnv, acronyms) => {
+    const realmKey = `serviceClient.keycloak.${kcEnv}`;
+    const {
+      endpoint: realmBaseUrl,
+      username: clientId,
+      password: clientSecret,
+      realm: realmId
+    } = config.get(realmKey);
+    const realmSvc = new RealmAdminService({ realmBaseUrl, clientId, clientSecret, realmId });
+    const kcScMgr = new KeyCloakServiceClientManager(realmSvc);
+    return kcScMgr.fetchClients(acronyms);
   }
 };
 

--- a/app/src/components/users.js
+++ b/app/src/components/users.js
@@ -1,6 +1,7 @@
 const config = require('config');
-const KeyCloakServiceClientManager = require('./keyCloakServiceClientMgr');
 const log = require('npmlog');
+
+const KeyCloakServiceClientManager = require('./keyCloakServiceClientMgr');
 const RealmAdminService = require('./realmAdminSvc');
 const { userService } = require('../services');
 
@@ -36,26 +37,24 @@ const users = {
     const acronyms = acronymsFromDb.map(acr => acr.acronym);
     log.debug('getUserAcronymClients', `Acronyms for user: ${JSON.stringify(acronyms)}`);
 
-    let [devClients, testClients, prodClients] = await Promise.all([
+    const [devClients, testClients, prodClients] = await Promise.all([
       users.getClientsFromEnv('dev', acronyms),
       users.getClientsFromEnv('test', acronyms),
       users.getClientsFromEnv('prod', acronyms)
     ]);
 
-    // This might be able to be better one-lined with map/reduce, but just not worth the time
-    const clientList = [];
-    acronyms.forEach(acr => {
+    return acronyms.map(acr => {
       const dc = devClients.find(cl => cl.clientId === `${acr}_SERVICE_CLIENT`);
       const tc = testClients.find(cl => cl.clientId === `${acr}_SERVICE_CLIENT`);
       const pc = prodClients.find(cl => cl.clientId === `${acr}_SERVICE_CLIENT`);
-      clientList.push({
+
+      return {
         acronym: acr,
         dev: dc ? dc : null,
         test: tc ? tc : null,
         prod: pc ? pc : null
-      });
+      };
     });
-    return clientList;
   },
   /**
    * @function getClientsFromEnv

--- a/app/tests/unit/components/keyCloakServiceClientMgr.spec.js
+++ b/app/tests/unit/components/keyCloakServiceClientMgr.spec.js
@@ -1,0 +1,170 @@
+//const axios = require('axios');
+const config = require('config');
+const log = require('npmlog');
+//const MockAdapter = require('axios-mock-adapter');
+//const mockAxios = new MockAdapter(axios);
+
+const KeyCloakServiceClientManager = require('../../../src/components/keyCloakServiceClientMgr');
+const RealmAdminService = require('../../../src/components/realmAdminSvc');
+const { acronymService } = require('../../../src/services');
+
+log.level = config.get('server.logLevel');
+log.addLevel('debug', 1500, { fg: 'cyan' });
+
+let realmConfig = {};
+let realmAdminService = undefined;
+let form = {};
+
+jest.mock('../../../src/components/realmAdminSvc', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      tokenUrl: 'https://tokenurl',
+      getClients: () => { return [{ id: 1, clientId: 'ZZZ_SERVICE_CLIENT' }, { id: 2, clientId: 'XXX_SERVICE_CLIENT' }, { id: 3, clientId: 'YYY_SERVICE_CLIENT' }]; },
+      createClient: () => { return { id: '1', clientId: 'generatedserviceclientid' }; },
+      getClientRoles: () => { return []; },
+      addClientRole: () => { return []; },
+      setRoleComposites: () => { },
+      getRoleComposites: () => { return [{ id: '456', name: 'GENERATOR', description: 'This role is.' }]; },
+      getServiceAccountUser: () => { return { id: '2', 'clientId': '1' }; },
+      addServiceAccountRole: () => { },
+      getUsers: () => { return [{ id: 1, username: 'me@idir' }, { id: 2, username: 'me@github' }]; },
+      getClientSecret: () => { return { value: 'itsasecret' }; }
+    };
+  });
+});
+
+beforeEach(() => {
+  const {
+    endpoint: realmBaseUrl,
+    username: clientId,
+    password: clientSecret,
+    realm: realmId
+  } = config.get('serviceClient.keyCloak.DEV');
+  realmConfig = { realmId, realmBaseUrl, clientId, clientSecret };
+  realmAdminService = new RealmAdminService(realmConfig);
+  form = { applicationAcronym: 'ABC', applicationName: 'Alphabet', applicationDescription: 'Easy as 1,2,3.', commonServices: ['cmn-srv-ex-a'] };
+});
+
+describe('KeyCloakServiceClientManager create', () => {
+  acronymService.updateDetails = jest.fn().mockResolvedValue();
+
+  it('should throw an error without realmAdminService', async () => {
+    expect(() => {
+      new KeyCloakServiceClientManager(undefined);
+    }).toThrow();
+  });
+
+  it('should return a Service Client Manager', async () => {
+    // eslint-disable-next-line no-unused-vars
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    expect(mgr).toBeTruthy();
+  });
+
+});
+
+describe('KeyCloakServiceClientManager manage', () => {
+  acronymService.updateDetails = jest.fn().mockResolvedValue();
+  const spyAcronym = jest.spyOn(acronymService, 'updateDetails');
+
+  afterEach(() => {
+    spyAcronym.mockClear();
+  });
+
+  it('should throw an error without applicationAcronym', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    form.applicationAcronym = undefined;
+    await expect(mgr.manage(form)).rejects.toThrow();
+  });
+
+  it('should throw an error without applicationName', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    form.applicationName = undefined;
+    await expect(mgr.manage(form)).rejects.toThrow();
+  });
+
+  it('should throw an error without applicationDescription', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    form.applicationDescription = undefined;
+    await expect(mgr.manage(form)).rejects.toThrow();
+  });
+
+  it('should throw an error without commonServices', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    form.commonServices = undefined;
+    await expect(mgr.manage(form)).rejects.toThrow();
+  });
+
+  it('should return a Service Client Manager', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    const r = await mgr.manage(form);
+    expect(spyAcronym).toHaveBeenCalledTimes(1);
+    expect(r).toBeTruthy();
+    expect(r.generatedPassword).toBeTruthy();
+    expect(r.generatedServiceClient).toBeTruthy();
+    expect(r.oidcTokenUrl).toBeTruthy();
+    expect(r.generatedServiceClient).toEqual('generatedserviceclientid');
+  }, 10000);
+
+});
+
+describe('KeyCloakServiceClientManager fetchClients', () => {
+  it('should throw an error without applicationAcronymList', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    await expect(mgr.fetchClients(undefined)).rejects.toThrow();
+  });
+
+  it('should throw an error with empty applicationAcronymList', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    await expect(mgr.fetchClients([])).rejects.toThrow();
+  });
+
+  it('should return a Service Client when a single acronym is passed in', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    const r = await mgr.fetchClients(['ZZZ']);
+    expect(r).toBeTruthy();
+    expect(r.length).toEqual(1);
+    expect(r[0].id).toEqual(1);
+    expect(r[0].clientId).toEqual('ZZZ_SERVICE_CLIENT');
+  });
+
+  it('should return only the relevant Service Clients when multiple acronyms are passed in', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    const r = await mgr.fetchClients(['ZZZ', 'YYY', 'ABC', '123']);
+    expect(r).toBeTruthy();
+    expect(r.length).toEqual(2);
+    expect(r[0].id).toEqual(1);
+    expect(r[0].clientId).toEqual('ZZZ_SERVICE_CLIENT');
+    expect(r[1].id).toEqual(3);
+    expect(r[1].clientId).toEqual('YYY_SERVICE_CLIENT');
+  });
+
+  it('should return undefined if a service client not found', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    const r = await mgr.fetchClients(['SDFH']);
+    expect(r).toEqual([]);
+  });
+
+});
+
+describe('KeyCloakServiceClientManager findUser', () => {
+  it('should throw an error without username', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    await expect(mgr.findUser(undefined)).rejects.toThrow();
+  });
+
+  it('should return a User', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    const r = await mgr.findUser('me@idir');
+    expect(r).toBeTruthy();
+    expect(r.username).toEqual('me@idir');
+  });
+});
+
+describe('KeyCloakServiceClientManager makeClientDetails', () => {
+  // Note: most tests of this method are excersized with fetchClients above
+  it('should throw an error without username', async () => {
+    const mgr = new KeyCloakServiceClientManager(realmAdminService);
+    const res = await mgr.makeClientDetails(undefined);
+    expect(res).toEqual(undefined);
+  });
+});

--- a/app/tests/unit/components/keyCloakServiceClientMgr.spec.js
+++ b/app/tests/unit/components/keyCloakServiceClientMgr.spec.js
@@ -39,7 +39,7 @@ beforeEach(() => {
     username: clientId,
     password: clientSecret,
     realm: realmId
-  } = config.get('serviceClient.keyCloak.DEV');
+  } = config.get('serviceClient.keycloak.dev');
   realmConfig = { realmId, realmBaseUrl, clientId, clientSecret };
   realmAdminService = new RealmAdminService(realmConfig);
   form = { applicationAcronym: 'ABC', applicationName: 'Alphabet', applicationDescription: 'Easy as 1,2,3.', commonServices: ['cmn-srv-ex-a'] };

--- a/app/tests/unit/components/realmAdminSvc.spec.js
+++ b/app/tests/unit/components/realmAdminSvc.spec.js
@@ -1,0 +1,561 @@
+const axios = require('axios');
+const config = require('config');
+const log = require('npmlog');
+const MockAdapter = require('axios-mock-adapter');
+const mockAxios = new MockAdapter(axios);
+
+const RealmAdminService = require('../../../src/components/realmAdminSvc');
+
+log.level = config.get('server.logLevel');
+
+let realmConfig = {};
+
+beforeEach(() => {
+  const {
+    endpoint: realmBaseUrl,
+    username: clientId,
+    password: clientSecret,
+    realm: realmId
+  } = config.get('serviceClient.keycloak.dev');
+  realmConfig = { realmId, realmBaseUrl, clientId, clientSecret };
+});
+
+describe('RealmAdminService create', () => {
+
+  it('should throw an error without realmId', async () => {
+    expect(() => {
+      const badConfig = { ...realmConfig };
+      delete badConfig.realmId;
+      new RealmAdminService(badConfig);
+    }).toThrow();
+  });
+  it('should throw an error without realmBaseUrl', async () => {
+    expect(() => {
+      const badConfig = { ...realmConfig };
+      delete badConfig.realmBaseUrl;
+      new RealmAdminService(badConfig);
+    }).toThrow();
+  });
+  it('should throw an error without clientId', async () => {
+    expect(() => {
+      const badConfig = { ...realmConfig };
+      delete badConfig.clientId;
+      new RealmAdminService(badConfig);
+    }).toThrow();
+  });
+  it('should throw an error without clientSecret', async () => {
+
+    expect(() => {
+      const badConfig = { ...realmConfig };
+      delete badConfig.clientSecret;
+      new RealmAdminService(badConfig);
+    }).toThrow();
+  });
+
+  it('should return a connection and realm admin url', async () => {
+    const result = new RealmAdminService(realmConfig);
+
+    expect(result).toBeTruthy();
+    expect(result.axios).toBeTruthy();
+    expect(result.realmAdminUrl).toBeTruthy();
+    expect(result.tokenUrl).toBeTruthy();
+
+  });
+
+});
+
+describe('RealmAdminService getRealm', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.getRealm()).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.getRealm()).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.getRealm()).rejects.toThrow();
+  });
+
+  it('should return realm information with valid connection', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onGet(svc.realmAdminUrl).reply(200, 'truthy');
+
+    const result = await svc.getRealm();
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService getClients', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.getClients()).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.getClients()).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.getClients()).rejects.toThrow();
+  });
+
+  it('should return clients', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onGet(`${svc.realmAdminUrl}/clients`).reply(200, 'truthy');
+
+    const result = await svc.getClients();
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService getClient', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.getClient('1')).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.getClient('1')).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.getClient('1')).rejects.toThrow();
+  });
+
+  it('should throw an error when null id parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.getClient(undefined)).rejects.toThrow();
+  });
+
+  it('should return a client', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onGet(`${svc.realmAdminUrl}/clients/1`).reply(200, 'truthy');
+
+    const result = await svc.getClient('1');
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService createClient', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.createClient('A', 'B', 'C')).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.createClient('A', 'B', 'C')).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.createClient('A', 'B', 'C')).rejects.toThrow();
+  });
+
+  it('should throw an error when null client id parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.createClient(undefined, 'B', 'C')).rejects.toThrow();
+  });
+
+  it('should throw an error when null client name parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.createClient('A', undefined, 'C')).rejects.toThrow();
+  });
+
+  it('should throw an error when null client description parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.createClient('A', 'B', undefined)).rejects.toThrow();
+  });
+
+  it('should return a new client', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onPost(`${svc.realmAdminUrl}/clients`).reply(201, 'truthy', { location: `${svc.realmAdminUrl}/clients/1` });
+    mockAxios.onGet(`${svc.realmAdminUrl}/clients/1`).reply(200, 'truthy');
+
+    const result = await svc.createClient('A', 'B', 'C');
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService updateClientDetails', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    const client = { id: '1' };
+    await expect(svc.updateClientDetails(client, 'B', 'C')).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    const client = { id: '1' };
+    await expect(svc.updateClientDetails(client, 'B', 'C')).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    const client = { id: '1' };
+    await expect(svc.updateClientDetails(client, 'B', 'C')).rejects.toThrow();
+  });
+
+  it('should throw an error when null client parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.updateClientDetails(undefined, 'B', 'C')).rejects.toThrow();
+  });
+
+  it('should throw an error when null client name parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    const client = { id: '1' };
+    await expect(svc.updateClientDetails(client, undefined, 'C')).rejects.toThrow();
+  });
+
+  it('should throw an error when null client description parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    const client = { id: '1' };
+    await expect(svc.updateClientDetails(client, undefined, undefined)).rejects.toThrow();
+  });
+
+  it('should return a new client', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onPut(`${svc.realmAdminUrl}/clients/1`).reply(204);
+    mockAxios.onGet(`${svc.realmAdminUrl}/clients/1`).reply(200, 'truthy');
+
+    const client = { id: '1' };
+    const result = await svc.updateClientDetails(client, 'B', 'C');
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService getClientSecret', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.getClientSecret('1')).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.getClientSecret('1')).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.getClientSecret('1')).rejects.toThrow();
+  });
+
+  it('should throw an error when null id parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.getClientSecret(undefined)).rejects.toThrow();
+  });
+
+  it('should return a client', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onGet(`${svc.realmAdminUrl}/clients/1/client-secret`).reply(200, 'truthy');
+
+    const result = await svc.getClientSecret('1');
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService getServiceAccountUser', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.getServiceAccountUser('1')).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.getServiceAccountUser('1')).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.getServiceAccountUser('1')).rejects.toThrow();
+  });
+
+  it('should throw an error when null id parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.getServiceAccountUser(undefined)).rejects.toThrow();
+  });
+
+  it('should return a service account user', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onGet(`${svc.realmAdminUrl}/clients/1/service-account-user`).reply(200, 'truthy');
+
+    const result = await svc.getServiceAccountUser('1');
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService getClientRoles', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.getClientRoles('1')).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.getClientRoles('1')).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.getClientRoles('1')).rejects.toThrow();
+  });
+
+  it('should throw an error when null id parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.getClientRoles(undefined)).rejects.toThrow();
+  });
+
+  it('should return client roles', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onGet(`${svc.realmAdminUrl}/clients/1/roles`).reply(200, 'truthy');
+
+    const result = await svc.getClientRoles('1');
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService removeClientRole', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.removeClientRole('1', 'theRole')).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.removeClientRole('1', 'theRole')).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.removeClientRole('1', 'theRole')).rejects.toThrow();
+  });
+
+  it('should throw an error when null id parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.removeClientRole(undefined, 'theRole')).rejects.toThrow();
+  });
+
+  it('should throw an error when null roleName parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.removeClientRole('1', undefined)).rejects.toThrow();
+  });
+
+  it('should return client roles', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onDelete(`${svc.realmAdminUrl}/clients/1/roles/theRole`).reply(204, 'truthy');
+
+    const result = await svc.removeClientRole('1', 'theRole');
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService addClientRole', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.addClientRole('1', 'theRole')).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.addClientRole('1', 'theRole')).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.addClientRole('1', 'theRole')).rejects.toThrow();
+  });
+
+  it('should throw an error when null id parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.addClientRole(undefined, 'theRole')).rejects.toThrow();
+  });
+
+  it('should throw an error when null roleName parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.addClientRole('1', undefined)).rejects.toThrow();
+  });
+
+  it('should return client roles', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onPost(`${svc.realmAdminUrl}/clients/1/roles`).reply(201, 'truthy');
+
+    const result = await svc.addClientRole('1', 'theRole');
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService addServiceAccountRole', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.addServiceAccountRole('SA', '1', { id: '2' })).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.addServiceAccountRole('SA', '1', { id: '2' })).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.addServiceAccountRole('SA', '1', { id: '2' })).rejects.toThrow();
+  });
+
+  it('should throw an error when null service account id parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.addServiceAccountRole(undefined, '1', { id: '2' })).rejects.toThrow();
+  });
+
+  it('should throw an error when null client id parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.addServiceAccountRole('SA', undefined, { id: '2' })).rejects.toThrow();
+  });
+
+  it('should throw an error when null role parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.addServiceAccountRole('SA', '1', undefined)).rejects.toThrow();
+  });
+
+  it('should return client roles', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onPost(`${svc.realmAdminUrl}/users/SA/role-mappings/clients/1`).reply(204, 'truthy');
+
+    const result = await svc.addServiceAccountRole('SA', '1', { id: '2' });
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService setRoleComposites', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.setRoleComposites({ id: '1' }, 'theRole', [{ id: '2' }])).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.setRoleComposites({ id: '1' }, 'theRole', [{ id: '2' }])).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.setRoleComposites({ id: '1' }, 'theRole', [{ id: '2' }])).rejects.toThrow();
+  });
+
+  it('should throw an error when null client parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.setRoleComposites(undefined, 'theRole', [{ id: '2' }])).rejects.toThrow();
+  });
+
+  it('should throw an error when null role name parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.setRoleComposites({ id: '1' }, undefined, [{ id: '2' }])).rejects.toThrow();
+  });
+
+  it('should throw an error when null roles parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.setRoleComposites({ id: '1' }, 'theRole', undefined)).rejects.toThrow();
+  });
+
+  it('should return client roles', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onPost(`${svc.realmAdminUrl}/clients/1/roles/theRole/composites`).reply(204, 'truthy');
+
+    const result = await svc.setRoleComposites({ id: '1' }, 'theRole', [{ id: '2' }]);
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('RealmAdminService getRoleComposites', () => {
+
+  it('should throw an error if no clientId provided', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.getRoleComposites(undefined, '')).rejects.toThrow();
+  });
+  it('should throw an error if no role name provided', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.getRoleComposites('abc-123', '')).rejects.toThrow();
+  });
+
+  it('should return composite roles', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onGet(`${svc.realmAdminUrl}/clients/1/roles/theRole/composites`).reply(204, 'yes returned');
+
+    const result = await svc.getRoleComposites('1', 'theRole');
+    expect(result).toBeTruthy();
+  });
+
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.getRoleComposites('1', 'theRole')).rejects.toThrow();
+  });
+
+});
+
+describe('RealmAdminService getUsers', () => {
+
+  it('should throw an error if no username provided', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.getUsers(undefined, '')).rejects.toThrow();
+  });
+
+  it('should return users', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onGet(`${svc.realmAdminUrl}/users?username=me@idir`).reply(204, 'yes returned');
+
+    const result = await svc.getUsers('me@idir');
+    expect(result).toBeTruthy();
+  });
+
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.getUsers('me')).rejects.toThrow();
+  });
+
+});

--- a/app/tests/unit/components/users.spec.js
+++ b/app/tests/unit/components/users.spec.js
@@ -111,7 +111,10 @@ describe('getUserAcronymClients', () => {
   it('should map service clients to envs when a client is found', async () => {
     findSpy.mockResolvedValue({});
     userAcronymListSpy.mockResolvedValue([{ acronym: 'ZZZ' }, { acronym: 'XXX' }]);
-    const mockClient = { environment: 'fake', id: '1234', clientId: 'XXX_SERVICE_CLIENT', enabled: true, name: 'XXX name', description: 'XXX desc', serviceAccountEmail: 'a@b.com' };
+    const mockClient = {
+      environment: 'fake', id: '1234', clientId: 'XXX_SERVICE_CLIENT', enabled: true, name: 'XXX name',
+      description: 'XXX desc', serviceAccountEmail: 'a@b.com'
+    };
     getClientsSpy.mockResolvedValue([mockClient]);
 
     const result = await users.getUserAcronymClients(zeroUuid);

--- a/backend/tests/unit/components/keyCloakServiceClientMgr.spec.js
+++ b/backend/tests/unit/components/keyCloakServiceClientMgr.spec.js
@@ -39,7 +39,7 @@ beforeEach(() => {
     username: clientId,
     password: clientSecret,
     realm: realmId
-  } = config.get('serviceClient.keyCloak.DEV');
+  } = config.get('serviceClient.keycloak.dev');
   realmConfig = { realmId, realmBaseUrl, clientId, clientSecret };
   realmAdminService = new RealmAdminService(realmConfig);
   form = { applicationAcronym: 'ABC', applicationName: 'Alphabet', applicationDescription: 'Easy as 1,2,3.', commonServices: ['cmn-srv-ex-a'] };

--- a/backend/tests/unit/components/realmAdminSvc.spec.js
+++ b/backend/tests/unit/components/realmAdminSvc.spec.js
@@ -16,7 +16,7 @@ beforeEach(() => {
     username: clientId,
     password: clientSecret,
     realm: realmId
-  } = config.get('serviceClient.keyCloak.DEV');
+  } = config.get('serviceClient.keycloak.dev');
   realmConfig = { realmId, realmBaseUrl, clientId, clientSecret };
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Add the Keycloak management classes in the API from the old code.
Wire them in to the FE call that displays them on the app list.
Some unit tests

**NOTE**: Reviewers, you can ignore the keyCloakServiceClientMgr.js and realmAdminSvc.js (and their spec test classes). These are ported in from the existing solution.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->