### PR TITLE
Reduce memory pressure on Jest tests and pipeline fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,12 +38,12 @@ pipeline {
     SOURCE_REPO_REF = "${JOB_NAME}"
     SOURCE_REPO_URL = "https://github.com/${REPO_OWNER}/${REPO_NAME}.git"
 
-    // HOST_ROUTE is the full domain without the path (ie. 'appname-k8vopl-dev.pathfinder.gov.bc.ca/pr-5')
+    // ENV_HOST is the full domain without the path (ie. 'appname-dev.pathfinder.gov.bc.ca')
     DEV_HOST = "${APP_NAME}-dev.${APP_DOMAIN}"
     TEST_HOST = "${APP_NAME}-test.${APP_DOMAIN}"
     PROD_HOST = "${APP_NAME}.${APP_DOMAIN}"
-    // will be added to the HOST_ROUTE
-    PATH_ROOT = "/${JOB_NAME}"
+    // PATH_ROOT will be appended to ENV_HOST
+    PATH_ROOT = "/${JOB_NAME.equalsIgnoreCase('master') ? APP_NAME : JOB_NAME}"
 
     // SonarQube Endpoint URL
     SONARQUBE_URL_INT = 'http://sonarqube:9000'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,50 +161,50 @@ pipeline {
       }
     }
 
-    // stage('Deploy - Test') {
-    //   agent any
-    //   steps {
-    //     script {
-    //       commonPipeline.runStageDeploy('Test', TEST_PROJECT, TEST_HOST, PATH_ROOT)
-    //     }
-    //   }
-    //   post {
-    //     success {
-    //       script {
-    //         commonPipeline.createDeploymentStatus(TEST_PROJECT, 'SUCCESS', JOB_NAME, TEST_HOST, PATH_ROOT)
-    //         commonPipeline.notifyStageStatus('Deploy - Test', 'SUCCESS')
-    //       }
-    //     }
-    //     unsuccessful {
-    //       script {
-    //         commonPipeline.createDeploymentStatus(TEST_PROJECT, 'FAILURE', JOB_NAME, TEST_HOST, PATH_ROOT)
-    //         commonPipeline.notifyStageStatus('Deploy - Test', 'FAILURE')
-    //       }
-    //     }
-    //   }
-    // }
+    stage('Deploy - Test') {
+      agent any
+      steps {
+        script {
+          commonPipeline.runStageDeploy('Test', TEST_PROJECT, TEST_HOST, PATH_ROOT)
+        }
+      }
+      post {
+        success {
+          script {
+            commonPipeline.createDeploymentStatus(TEST_PROJECT, 'SUCCESS', JOB_NAME, TEST_HOST, PATH_ROOT)
+            commonPipeline.notifyStageStatus('Deploy - Test', 'SUCCESS')
+          }
+        }
+        unsuccessful {
+          script {
+            commonPipeline.createDeploymentStatus(TEST_PROJECT, 'FAILURE', JOB_NAME, TEST_HOST, PATH_ROOT)
+            commonPipeline.notifyStageStatus('Deploy - Test', 'FAILURE')
+          }
+        }
+      }
+    }
 
-    // stage('Deploy - Prod') {
-    //   agent any
-    //   steps {
-    //     script {
-    //       commonPipeline.runStageDeploy('Prod', PROD_PROJECT, PROD_HOST, PATH_ROOT)
-    //     }
-    //   }
-    //   post {
-    //     success {
-    //       script {
-    //         commonPipeline.createDeploymentStatus(PROD_PROJECT, 'SUCCESS', JOB_NAME, PROD_HOST, PATH_ROOT)
-    //         commonPipeline.notifyStageStatus('Deploy - Prod', 'SUCCESS')
-    //       }
-    //     }
-    //     unsuccessful {
-    //       script {
-    //         commonPipeline.createDeploymentStatus(PROD_PROJECT, 'FAILURE', JOB_NAME, PROD_HOST, PATH_ROOT)
-    //         commonPipeline.notifyStageStatus('Deploy - Prod', 'FAILURE')
-    //       }
-    //     }
-    //   }
-    // }
+    stage('Deploy - Prod') {
+      agent any
+      steps {
+        script {
+          commonPipeline.runStageDeploy('Prod', PROD_PROJECT, PROD_HOST, PATH_ROOT)
+        }
+      }
+      post {
+        success {
+          script {
+            commonPipeline.createDeploymentStatus(PROD_PROJECT, 'SUCCESS', JOB_NAME, PROD_HOST, PATH_ROOT)
+            commonPipeline.notifyStageStatus('Deploy - Prod', 'SUCCESS')
+          }
+        }
+        unsuccessful {
+          script {
+            commonPipeline.createDeploymentStatus(PROD_PROJECT, 'FAILURE', JOB_NAME, PROD_HOST, PATH_ROOT)
+            commonPipeline.notifyStageStatus('Deploy - Prod', 'FAILURE')
+          }
+        }
+      }
+    }
   }
 }

--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -38,12 +38,12 @@ pipeline {
     SOURCE_REPO_REF = "pull/${CHANGE_ID}/head"
     SOURCE_REPO_URL = "https://github.com/${REPO_OWNER}/${REPO_NAME}.git"
 
-    // HOST_ROUTE is the full domain without the path (ie. 'appname-k8vopl-dev.pathfinder.gov.bc.ca/pr-5')
+    // ENV_HOST is the full domain without the path (ie. 'appname-dev.pathfinder.gov.bc.ca')
     DEV_HOST = "${APP_NAME}-dev.${APP_DOMAIN}"
     TEST_HOST = "${APP_NAME}-test.${APP_DOMAIN}"
     PROD_HOST = "${APP_NAME}.${APP_DOMAIN}"
-    // will be added to the HOST_ROUTE
-    PATH_ROOT = "/${JOB_NAME}"
+    // PATH_ROOT will be appended to ENV_HOST
+    PATH_ROOT = "/${JOB_NAME.equalsIgnoreCase('master') ? APP_NAME : JOB_NAME}"
 
     // SonarQube Endpoint URL
     SONARQUBE_URL_INT = 'http://sonarqube:9000'

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -17,7 +17,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test": "npm run test:unit",
-    "test:unit": "vue-cli-service test:unit --verbose",
+    "test:unit": "vue-cli-service test:unit --verbose --forceExit --detectOpenHandles --maxWorkers=10",
     "lint": "vue-cli-service lint",
     "lint:fix": "vue-cli-service lint --fix",
     "pretest": "npm run lint",

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
     "serve": "nodemon ./bin/www",
     "build": "cd frontend && npm run build",
     "start": "node ./bin/www",
-    "test": "jest --verbose",
+    "test": "jest --verbose --forceExit --detectOpenHandles --maxWorkers=10",
     "lint": "eslint . **/www --no-fix --ext .js",
     "lint:fix": "eslint . **/www --fix --ext .js",
     "migrate": "sequelize db:migrate",

--- a/openshift/commonPipeline.groovy
+++ b/openshift/commonPipeline.groovy
@@ -8,35 +8,41 @@ import bcgov.GitHubHelper
 // Run Tests
 def runStageTests() {
   timeout(time: 10, unit: 'MINUTES') {
-    dir('app') {
-      try {
-        echo 'Installing NPM Dependencies...'
-        sh 'npm ci'
+    parallel(
+      App: {
+        dir('app') {
+          try {
+            echo 'Installing NPM Dependencies...'
+            sh 'npm ci'
 
-        echo 'Linting and Testing App...'
-        sh 'npm run test'
+            echo 'Linting and Testing App...'
+            sh 'npm run test'
 
-        echo 'App Lint Checks and Tests passed'
-      } catch (e) {
-        echo 'App Lint Checks and Tests failed'
-        throw e
+            echo 'App Lint Checks and Tests passed'
+          } catch (e) {
+            echo 'App Lint Checks and Tests failed'
+            throw e
+          }
+        }
+      },
+
+      Frontend: {
+        dir('app/frontend') {
+          try {
+            echo 'Installing NPM Dependencies...'
+            sh 'npm ci'
+
+            echo 'Linting and Testing Frontend...'
+            sh 'npm run test'
+
+            echo 'Frontend Lint Checks and Tests passed'
+          } catch (e) {
+            echo 'Frontend Lint Checks and Tests failed'
+            throw e
+          }
+        }
       }
-    }
-
-    dir('app/frontend') {
-      try {
-        echo 'Installing NPM Dependencies...'
-        sh 'npm ci'
-
-        echo 'Linting and Testing Frontend...'
-        sh 'npm run test'
-
-        echo 'Frontend Lint Checks and Tests passed'
-      } catch (e) {
-        echo 'Frontend Lint Checks and Tests failed'
-        throw e
-      }
-    }
+    )
   }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR reverts the temporary change to tests running in sequence. By limiting the number of Jest workers, we can control how much memory is used, and therefore re-allow the app and frontend to run in parallel again, and sets the default root path to /getok when it is on the master branch for deployment.
This PR also restores the ability to deploy to Test and Prod environments.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-937](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-937)
[SHOWCASE-948](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-948)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->