### PR TITLE
PW should reset for existing clients

### DIFF
--- a/app/frontend/src/components/Team.vue
+++ b/app/frontend/src/components/Team.vue
@@ -85,7 +85,7 @@ export default {
           email: u.user.email
         };
       });
-    } catch {
+    } catch (error) {
       //TODO: still pending descisions on global error standardization
       this.errorLoadingUsers = true;
     } finally {

--- a/app/src/components/keyCloakServiceClientMgr.js
+++ b/app/src/components/keyCloakServiceClientMgr.js
@@ -42,6 +42,10 @@ class KeyCloakServiceClientManager {
     } else {
       // may have changed the name and description...
       serviceClient = await this.svc.updateClientDetails(serviceClient, applicationName, applicationDescription);
+      // generate new password
+      // TODO: if this gets moved to a separate action, where it's not updating client details at the same time
+      // move this generate new call out of manage to a separate call through this class
+      await this.svc.generateNewClientSecret(serviceClient.id);
     }
 
     // get all the selected common services and their roles

--- a/app/src/components/realmAdminSvc.js
+++ b/app/src/components/realmAdminSvc.js
@@ -231,6 +231,26 @@ class RealmAdminService {
     return response.data;
   }
 
+  async generateNewClientSecret(id) {
+    if (!id) {
+      log.error('RealmAdminService generateNewClientSecret id parameter is null.');
+      throw new Error('Cannot update client secret: id parameter cannot be null.');
+    }
+
+    const response = await this.axios.post(
+      `${this.realmAdminUrl}/clients/${id}/client-secret`,
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    ).catch(e => {
+      log.error('RealmAdminService.generateNewClientSecret', JSON.stringify(e));
+      throw e;
+    });
+    return response.data;
+  }
+
   async getServiceAccountUser(id) {
     if (!id) {
       log.error('RealmAdminService getServiceAccountUser id parameter is null.');

--- a/app/src/components/realmAdminSvc.js
+++ b/app/src/components/realmAdminSvc.js
@@ -233,7 +233,7 @@ class RealmAdminService {
 
   async generateNewClientSecret(id) {
     if (!id) {
-      log.error('RealmAdminService generateNewClientSecret id parameter is null.');
+      log.error('RealmAdminService.generateNewClientSecret', 'RealmAdminService generateNewClientSecret id parameter is null.');
       throw new Error('Cannot update client secret: id parameter cannot be null.');
     }
 

--- a/app/tests/unit/components/keyCloakServiceClientMgr.spec.js
+++ b/app/tests/unit/components/keyCloakServiceClientMgr.spec.js
@@ -27,7 +27,8 @@ jest.mock('../../../src/components/realmAdminSvc', () => {
       getServiceAccountUser: () => { return { id: '2', 'clientId': '1' }; },
       addServiceAccountRole: () => { },
       getUsers: () => { return [{ id: 1, username: 'me@idir' }]; },
-      getClientSecret: () => { return { value: 'itsasecret' }; }
+      getClientSecret: () => { return { value: 'itsasecret' }; },
+      generateNewClientSecret: () => { return { value: 'newsecret' }; }
     };
   });
 });
@@ -148,7 +149,7 @@ describe('KeyCloakServiceClientManager fetchClients', () => {
 describe('KeyCloakServiceClientManager findUsers', () => {
   it('should return a User', async () => {
     const mgr = new KeyCloakServiceClientManager(realmAdminService);
-    const r = await mgr.findUsers({username: 'me@idir'});
+    const r = await mgr.findUsers({ username: 'me@idir' });
     expect(r[0]).toBeTruthy();
     expect(r[0].username).toEqual('me@idir');
   });

--- a/app/tests/unit/components/realmAdminSvc.spec.js
+++ b/app/tests/unit/components/realmAdminSvc.spec.js
@@ -282,7 +282,7 @@ describe('RealmAdminService getClientSecret', () => {
 
 describe('RealmAdminService generateNewClientSecret', () => {
 
-  it('should throw an error connection is not set', async () => {
+  it('should throw an error if axios undefined', async () => {
     const svc = new RealmAdminService(realmConfig);
     svc.axios = undefined;
     await expect(svc.generateNewClientSecret('1')).rejects.toThrow();

--- a/app/tests/unit/components/realmAdminSvc.spec.js
+++ b/app/tests/unit/components/realmAdminSvc.spec.js
@@ -280,6 +280,39 @@ describe('RealmAdminService getClientSecret', () => {
   });
 });
 
+describe('RealmAdminService generateNewClientSecret', () => {
+
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = undefined;
+    await expect(svc.generateNewClientSecret('1')).rejects.toThrow();
+  });
+  it('should throw an error connection is not set', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.realmAdminUrl = undefined;
+    await expect(svc.generateNewClientSecret('1')).rejects.toThrow();
+  });
+  it('should throw an error when realm url is bad...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    mockAxios.onGet(svc.realmAdminUrl).reply(500);
+    await expect(svc.generateNewClientSecret('1')).rejects.toThrow();
+  });
+
+  it('should throw an error when null id parameter...', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    await expect(svc.generateNewClientSecret(undefined)).rejects.toThrow();
+  });
+
+  it('should return a secret update response', async () => {
+    const svc = new RealmAdminService(realmConfig);
+    svc.axios = axios.create();
+    mockAxios.onPost(`${svc.realmAdminUrl}/clients/1/client-secret`).reply(200, 'truthy');
+
+    const result = await svc.generateNewClientSecret('1');
+    expect(result).toBeTruthy();
+  });
+});
+
 describe('RealmAdminService getServiceAccountUser', () => {
 
   it('should throw an error connection is not set', async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-954
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Should reset the password when updating an existing service client.

Added a call to 'manage' in the KC service manager to do it, would be probably better to extract out to a specific 'reset' functionality, but for not since the UI is tied together it needs to be able to update the name/description at the same time.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

 Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->