### PR TITLE
Override default KC max returned value

### DIFF
--- a/app/src/components/users.js
+++ b/app/src/components/users.js
@@ -28,7 +28,7 @@ const users = {
       realmId,
     });
     const kcScMgr = new KeyCloakServiceClientManager(realmSvc);
-    return kcScMgr.findUsers();
+    return kcScMgr.findUsers({max: 2147483647});
   },
 
   /**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Overrides the default Keycloak value for max number of returned users. KC default is 100, our realm currently has 127, so users were not appearing in some lists.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->